### PR TITLE
2023早春イベントの対潜空襲マスに暫定対応

### DIFF
--- a/src/main/java/logbook/internal/JsonHelper.java
+++ b/src/main/java/logbook/internal/JsonHelper.java
@@ -41,7 +41,8 @@ public final class JsonHelper {
     }
 
     /**
-     * JsonValueをIntegerに変換します
+     * JsonValueをIntegerに変換します<br>
+     * 値が"N/A"の場合、nullを設定します
      *
      * @see JsonNumber#intValue()
      * @see BigDecimal#intValue()
@@ -51,6 +52,9 @@ public final class JsonHelper {
     public static Integer toInteger(JsonValue val) {
         if (val instanceof JsonNumber) {
             return ((JsonNumber) val).intValue();
+        }
+        if (val instanceof JsonString) {
+            if(((JsonString) val).getString().equals("N/A"))return null;
         }
         return new BigDecimal(toString(val)).intValue();
     }
@@ -615,6 +619,7 @@ public final class JsonHelper {
         public <T extends JsonArray> Bind setIntegerList(String key, Consumer<List<Integer>> consumer) {
             return this.set(key, consumer, JsonHelper::toIntegerList);
         }
+
 
         /**
          * keyで取得したJsonValueをList<Long>に変換したものをconsumerへ設定します<br>

--- a/src/main/java/logbook/internal/PhaseState.java
+++ b/src/main/java/logbook/internal/PhaseState.java
@@ -750,7 +750,7 @@ public class PhaseState {
             }
         }
         for (int i = 0, s = b.getEMaxhps().size(); i < s; i++) {
-            if (b.getEMaxhps().get(i) == -1) {
+            if (b.getEMaxhps().get(i) != null && b.getEMaxhps().get(i) == -1) {
                 continue;
             }
             if (this.afterEnemy.get(i) != null) {
@@ -921,7 +921,9 @@ public class PhaseState {
     public double enemyTotalHp() {
         return Stream.concat(this.afterEnemy.stream(), this.afterEnemyCombined.stream())
                 .filter(Objects::nonNull)
-                .mapToInt(Chara::getNowhp)
+                .map(Chara::getNowhp)
+                .filter(Objects::nonNull)
+                .mapToInt(Integer::intValue)
                 .map(hp -> Math.max(hp, 0))
                 .sum();
     }
@@ -947,7 +949,9 @@ public class PhaseState {
     public int enemydAliveCount() {
         return (int) Stream.concat(this.afterEnemy.stream(), this.afterEnemyCombined.stream())
                 .filter(Objects::nonNull)
-                .mapToInt(Chara::getNowhp)
+                .map(Chara::getNowhp)
+                .filter(Objects::nonNull)
+                .mapToInt(Integer::intValue)
                 .filter(hp -> hp > 0)
                 .count();
     }

--- a/src/main/java/logbook/internal/ShipImage.java
+++ b/src/main/java/logbook/internal/ShipImage.java
@@ -191,7 +191,8 @@ class ShipImage {
     static Image get(Chara chara, boolean addItem, boolean applyState,
             Map<Integer, SlotItem> itemMap, Set<Integer> escape) {
         boolean visibleExpGauge = AppConfig.get().isVisibleExpGauge();
-        return get(chara, addItem, applyState, true, true, true, visibleExpGauge, itemMap, escape);
+        boolean visibleHpGauge = chara.getMaxhp() == null ? false : true;
+        return get(chara, addItem, applyState, true, true, visibleHpGauge, visibleExpGauge, itemMap, escape);
     }
 
     /**

--- a/src/main/java/logbook/internal/Ships.java
+++ b/src/main/java/logbook/internal/Ships.java
@@ -273,6 +273,7 @@ public class Ships {
      * @return 撃沈状態の場合true
      */
     public static boolean isLost(Chara chara) {
+        if (chara.getNowhp() == null)return false;
         return chara.getNowhp() <= 0;
     }
 
@@ -1079,6 +1080,7 @@ public class Ships {
      * @return HP割合
      */
     private static double hpPer(Chara chara) {
+        if (chara.getMaxhp() == null)return 0;
         return (double) chara.getNowhp() / (double) chara.getMaxhp();
     }
 

--- a/src/main/java/logbook/internal/gui/BattleDetailPhaseShip.java
+++ b/src/main/java/logbook/internal/gui/BattleDetailPhaseShip.java
@@ -66,6 +66,8 @@ public class BattleDetailPhaseShip extends HBox {
     void initialize() {
         this.img.setImage(Ships.shipWithItemWithoutStateBannerImage(this.chara, this.itemMap, this.escape));
         this.name.setText(Ships.toName(this.chara));
-        this.hp.setText(this.chara.getNowhp() + "/" + this.chara.getMaxhp());
+        if(this.chara.getMaxhp() != null) {
+            this.hp.setText(this.chara.getNowhp() + "/" + this.chara.getMaxhp());
+        }
     }
 }


### PR DESCRIPTION
#### 変更内容
- 2023早春イベントの対潜空襲マスに暫定対応
現在の戦闘での表示（艦イメージ位置は従来のまま）
戦闘ログに記録
 