### PR TITLE
「現在の戦闘」「現在の演習」で稀に切り替わらない事象を修正

### DIFF
--- a/logbook/src/main/java/logbook/api/ApiReqBattleMidnightBattle.java
+++ b/logbook/src/main/java/logbook/api/ApiReqBattleMidnightBattle.java
@@ -45,6 +45,8 @@ public class ApiReqBattleMidnightBattle implements APIListenerSpi {
                                     .filter(Objects::nonNull)
                                     .collect(Collectors.toMap(Ship::getId, v -> v)));
                 }
+                // 戦闘結果更新を通知
+                AppCondition.get().notifyBattleResultUpdated();
             }
         }
     }

--- a/logbook/src/main/java/logbook/api/ApiReqBattleMidnightSpMidnight.java
+++ b/logbook/src/main/java/logbook/api/ApiReqBattleMidnightSpMidnight.java
@@ -57,6 +57,8 @@ public class ApiReqBattleMidnightSpMidnight implements APIListenerSpi {
                                     .filter(Objects::nonNull)
                                     .collect(Collectors.toMap(Ship::getId, v -> v)));
                 }
+                // 戦闘結果更新を通知
+                condition.notifyBattleResultUpdated();
             }
         }
     }

--- a/logbook/src/main/java/logbook/api/ApiReqCombinedBattleAirbattle.java
+++ b/logbook/src/main/java/logbook/api/ApiReqCombinedBattleAirbattle.java
@@ -54,6 +54,8 @@ public class ApiReqCombinedBattleAirbattle implements APIListenerSpi {
                                     .filter(Objects::nonNull)
                                     .collect(Collectors.toMap(Ship::getId, v -> v)));
                 }
+                // 戦闘結果更新を通知
+                condition.notifyBattleResultUpdated();
             }
         }
     }

--- a/logbook/src/main/java/logbook/api/ApiReqCombinedBattleBattle.java
+++ b/logbook/src/main/java/logbook/api/ApiReqCombinedBattleBattle.java
@@ -54,6 +54,8 @@ public class ApiReqCombinedBattleBattle implements APIListenerSpi {
                                     .filter(Objects::nonNull)
                                     .collect(Collectors.toMap(Ship::getId, v -> v)));
                 }
+                // 戦闘結果更新を通知
+                condition.notifyBattleResultUpdated();
             }
         }
     }

--- a/logbook/src/main/java/logbook/api/ApiReqCombinedBattleBattleWater.java
+++ b/logbook/src/main/java/logbook/api/ApiReqCombinedBattleBattleWater.java
@@ -54,6 +54,8 @@ public class ApiReqCombinedBattleBattleWater implements APIListenerSpi {
                                     .filter(Objects::nonNull)
                                     .collect(Collectors.toMap(Ship::getId, v -> v)));
                 }
+                // 戦闘結果更新を通知
+                condition.notifyBattleResultUpdated();
             }
         }
     }

--- a/logbook/src/main/java/logbook/api/ApiReqCombinedBattleBattleresult.java
+++ b/logbook/src/main/java/logbook/api/ApiReqCombinedBattleBattleresult.java
@@ -78,6 +78,9 @@ public class ApiReqCombinedBattleBattleresult implements APIListenerSpi {
                                     .filter(Objects::nonNull)
                                     .collect(Collectors.toMap(Ship::getId, v -> v)));
                 }
+                // 戦闘結果更新を通知（結果が設定されたため）
+                // logを引数として渡すことで、battleResultConfirmに設定されたlogをリスナーに渡す
+                AppCondition.get().notifyBattleResultUpdated(log);
             }
             if (result.achievementGimmick1()) {
                 Platform.runLater(

--- a/logbook/src/main/java/logbook/api/ApiReqCombinedBattleEachBattle.java
+++ b/logbook/src/main/java/logbook/api/ApiReqCombinedBattleEachBattle.java
@@ -56,6 +56,8 @@ public class ApiReqCombinedBattleEachBattle implements APIListenerSpi {
                                     .filter(Objects::nonNull)
                                     .collect(Collectors.toMap(Ship::getId, v -> v)));
                 }
+                // 戦闘結果更新を通知
+                condition.notifyBattleResultUpdated();
             }
         }
     }

--- a/logbook/src/main/java/logbook/api/ApiReqCombinedBattleEcBattle.java
+++ b/logbook/src/main/java/logbook/api/ApiReqCombinedBattleEcBattle.java
@@ -57,6 +57,8 @@ public class ApiReqCombinedBattleEcBattle implements APIListenerSpi {
                                     .filter(Objects::nonNull)
                                     .collect(Collectors.toMap(Ship::getId, v -> v)));
                 }
+                // 戦闘結果更新を通知
+                condition.notifyBattleResultUpdated();
             }
         }
     }

--- a/logbook/src/main/java/logbook/api/ApiReqCombinedBattleEcMidnightBattle.java
+++ b/logbook/src/main/java/logbook/api/ApiReqCombinedBattleEcMidnightBattle.java
@@ -48,6 +48,8 @@ public class ApiReqCombinedBattleEcMidnightBattle implements APIListenerSpi {
                                     .filter(Objects::nonNull)
                                     .collect(Collectors.toMap(Ship::getId, v -> v)));
                 }
+                // 戦闘結果更新を通知
+                AppCondition.get().notifyBattleResultUpdated();
             }
         }
     }

--- a/logbook/src/main/java/logbook/api/ApiReqCombinedBattleEcNightToDay.java
+++ b/logbook/src/main/java/logbook/api/ApiReqCombinedBattleEcNightToDay.java
@@ -59,6 +59,8 @@ public class ApiReqCombinedBattleEcNightToDay implements APIListenerSpi {
                                     .filter(Objects::nonNull)
                                     .collect(Collectors.toMap(Ship::getId, v -> v)));
                 }
+                // 戦闘結果更新を通知
+                condition.notifyBattleResultUpdated();
             }
         }
     }

--- a/logbook/src/main/java/logbook/api/ApiReqCombinedBattleLdAirbattle.java
+++ b/logbook/src/main/java/logbook/api/ApiReqCombinedBattleLdAirbattle.java
@@ -54,6 +54,8 @@ public class ApiReqCombinedBattleLdAirbattle implements APIListenerSpi {
                                     .filter(Objects::nonNull)
                                     .collect(Collectors.toMap(Ship::getId, v -> v)));
                 }
+                // 戦闘結果更新を通知
+                condition.notifyBattleResultUpdated();
             }
         }
     }

--- a/logbook/src/main/java/logbook/api/ApiReqCombinedBattleMidnightBattle.java
+++ b/logbook/src/main/java/logbook/api/ApiReqCombinedBattleMidnightBattle.java
@@ -48,6 +48,8 @@ public class ApiReqCombinedBattleMidnightBattle implements APIListenerSpi {
                                     .filter(Objects::nonNull)
                                     .collect(Collectors.toMap(Ship::getId, v -> v)));
                 }
+                // 戦闘結果更新を通知
+                AppCondition.get().notifyBattleResultUpdated();
             }
         }
     }

--- a/logbook/src/main/java/logbook/api/ApiReqCombinedBattleSpMidnight.java
+++ b/logbook/src/main/java/logbook/api/ApiReqCombinedBattleSpMidnight.java
@@ -54,6 +54,8 @@ public class ApiReqCombinedBattleSpMidnight implements APIListenerSpi {
                                     .filter(Objects::nonNull)
                                     .collect(Collectors.toMap(Ship::getId, v -> v)));
                 }
+                // 戦闘結果更新を通知
+                condition.notifyBattleResultUpdated();
             }
         }
     }

--- a/logbook/src/main/java/logbook/api/ApiReqPracticeBattle.java
+++ b/logbook/src/main/java/logbook/api/ApiReqPracticeBattle.java
@@ -34,6 +34,8 @@ public class ApiReqPracticeBattle implements APIListenerSpi {
                         .orElse(1);
                 // 艦隊スナップショットを作る
                 BattleLog.snapshot(log, dockId);
+                // 演習結果更新を通知
+                AppCondition.get().notifyPracticeBattleResultUpdated();
             }
         } catch (Throwable e) {
             e.printStackTrace();

--- a/logbook/src/main/java/logbook/api/ApiReqPracticeBattleresult.java
+++ b/logbook/src/main/java/logbook/api/ApiReqPracticeBattleresult.java
@@ -35,6 +35,8 @@ public class ApiReqPracticeBattleresult implements APIListenerSpi {
                             .orElse(1);
                     // 艦隊スナップショットを作る
                     BattleLog.snapshot(log, dockId);
+                    // 演習結果更新を通知
+                    AppCondition.get().notifyPracticeBattleResultUpdated();
                 }
             }
         } catch (Throwable e) {

--- a/logbook/src/main/java/logbook/api/ApiReqPracticeMidnightBattle.java
+++ b/logbook/src/main/java/logbook/api/ApiReqPracticeMidnightBattle.java
@@ -23,6 +23,8 @@ public class ApiReqPracticeMidnightBattle implements APIListenerSpi {
             BattleLog log = AppCondition.get().getPracticeBattleResult();
             if (log != null) {
                 log.setMidnight(BattleMidnightBattle.toBattle(data));
+                // 演習結果更新を通知
+                AppCondition.get().notifyPracticeBattleResultUpdated();
             }
         }
     }

--- a/logbook/src/main/java/logbook/api/ApiReqSortieAirbattle.java
+++ b/logbook/src/main/java/logbook/api/ApiReqSortieAirbattle.java
@@ -57,6 +57,8 @@ public class ApiReqSortieAirbattle implements APIListenerSpi {
                                     .filter(Objects::nonNull)
                                     .collect(Collectors.toMap(Ship::getId, v -> v)));
                 }
+                // 戦闘結果更新を通知
+                condition.notifyBattleResultUpdated();
             }
         }
     }

--- a/logbook/src/main/java/logbook/api/ApiReqSortieBattle.java
+++ b/logbook/src/main/java/logbook/api/ApiReqSortieBattle.java
@@ -57,6 +57,8 @@ public class ApiReqSortieBattle implements APIListenerSpi {
                                     .filter(Objects::nonNull)
                                     .collect(Collectors.toMap(Ship::getId, v -> v)));
                 }
+                // 戦闘結果更新を通知
+                condition.notifyBattleResultUpdated();
             }
         }
     }

--- a/logbook/src/main/java/logbook/api/ApiReqSortieBattleresult.java
+++ b/logbook/src/main/java/logbook/api/ApiReqSortieBattleresult.java
@@ -76,6 +76,9 @@ public class ApiReqSortieBattleresult implements APIListenerSpi {
                                     .filter(Objects::nonNull)
                                     .collect(Collectors.toMap(Ship::getId, v -> v)));
                 }
+                // 戦闘結果更新を通知（結果が設定されたため）
+                // logを引数として渡すことで、battleResultConfirmに設定されたlogをリスナーに渡す
+                AppCondition.get().notifyBattleResultUpdated(log);
             }
             if (result.achievementGimmick1()) {
                 Platform.runLater(

--- a/logbook/src/main/java/logbook/api/ApiReqSortieLdAirbattle.java
+++ b/logbook/src/main/java/logbook/api/ApiReqSortieLdAirbattle.java
@@ -57,6 +57,8 @@ public class ApiReqSortieLdAirbattle implements APIListenerSpi {
                                     .filter(Objects::nonNull)
                                     .collect(Collectors.toMap(Ship::getId, v -> v)));
                 }
+                // 戦闘結果更新を通知
+                condition.notifyBattleResultUpdated();
             }
         }
     }

--- a/logbook/src/main/java/logbook/api/ApiReqSortieLdShooting.java
+++ b/logbook/src/main/java/logbook/api/ApiReqSortieLdShooting.java
@@ -57,6 +57,8 @@ public class ApiReqSortieLdShooting implements APIListenerSpi {
                                     .filter(Objects::nonNull)
                                     .collect(Collectors.toMap(Ship::getId, v -> v)));
                 }
+                // 戦闘結果更新を通知
+                condition.notifyBattleResultUpdated();
             }
         }
     }

--- a/logbook/src/main/java/logbook/bean/AppCondition.java
+++ b/logbook/src/main/java/logbook/bean/AppCondition.java
@@ -5,15 +5,22 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import javafx.application.Platform;
 import logbook.internal.Config;
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 出撃などの状態
  *
  */
+@Slf4j
 @Data
 public class AppCondition implements Serializable {
 
@@ -60,6 +67,271 @@ public class AppCondition implements Serializable {
 
     /** ルート(mapping.jsonを参照) */
     private List<String> route = new ArrayList<>();
+
+    /** 戦闘結果更新リスナー（シリアライズ対象外） */
+    @JsonIgnore
+    private transient final List<NamedListener<BattleResultUpdateListener>> battleResultUpdateListeners = new CopyOnWriteArrayList<>();
+
+    /** 演習結果更新リスナー（シリアライズ対象外） */
+    @JsonIgnore
+    private transient final List<NamedListener<PracticeBattleResultUpdateListener>> practiceBattleResultUpdateListeners = new CopyOnWriteArrayList<>();
+
+    /**
+     * 名前付きリスナー
+     * リスナーとその名前を保持する内部クラス
+     *
+     * @param <T> リスナーの型
+     */
+    private static class NamedListener<T> {
+        private final T listener;
+        private final String name;
+
+        NamedListener(T listener, String name) {
+            this.listener = listener;
+            this.name = name;
+        }
+
+        T getListener() {
+            return this.listener;
+        }
+
+        String getName() {
+            return this.name;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || this.getClass() != obj.getClass()) {
+                return false;
+            }
+            NamedListener<?> that = (NamedListener<?>) obj;
+            return Objects.equals(this.listener, that.listener);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.listener);
+        }
+    }
+
+    /**
+     * 戦闘ログ更新リスナー
+     * 戦闘ログが更新された際に呼び出される共通の関数型インターフェース
+     */
+    @FunctionalInterface
+    public interface BattleLogUpdateListener {
+        /**
+         * 戦闘ログが更新された際に呼び出されます
+         *
+         * @param log 更新された戦闘ログ（nullの可能性あり）
+         */
+        void onBattleLogUpdated(BattleLog log);
+    }
+
+    /**
+     * 戦闘結果更新リスナー
+     * 戦闘結果が更新された際に呼び出される関数型インターフェース
+     * {@link BattleLogUpdateListener}のエイリアス
+     */
+    @FunctionalInterface
+    public interface BattleResultUpdateListener extends BattleLogUpdateListener {
+        /**
+         * 戦闘結果が更新された際に呼び出されます
+         *
+         * @param log 更新された戦闘ログ（nullの可能性あり）
+         */
+        @Override
+        default void onBattleLogUpdated(BattleLog log) {
+            this.onBattleResultUpdated(log);
+        }
+
+        /**
+         * 戦闘結果が更新された際に呼び出されます
+         *
+         * @param log 更新された戦闘ログ（nullの可能性あり）
+         */
+        void onBattleResultUpdated(BattleLog log);
+    }
+
+    /**
+     * 演習結果更新リスナー
+     * 演習結果が更新された際に呼び出される関数型インターフェース
+     * {@link BattleLogUpdateListener}のエイリアス
+     */
+    @FunctionalInterface
+    public interface PracticeBattleResultUpdateListener extends BattleLogUpdateListener {
+        /**
+         * 演習結果が更新された際に呼び出されます
+         *
+         * @param log 更新された戦闘ログ（nullの可能性あり）
+         */
+        @Override
+        default void onBattleLogUpdated(BattleLog log) {
+            this.onPracticeBattleResultUpdated(log);
+        }
+
+        /**
+         * 演習結果が更新された際に呼び出されます
+         *
+         * @param log 更新された戦闘ログ（nullの可能性あり）
+         */
+        void onPracticeBattleResultUpdated(BattleLog log);
+    }
+
+    /**
+     * 戦闘結果更新リスナーを登録します
+     * 既に登録されているリスナーは重複登録されません
+     *
+     * @param listener リスナー（null不可）
+     * @throws NullPointerException listenerがnullの場合
+     */
+    public void addBattleResultUpdateListener(BattleResultUpdateListener listener) {
+        this.addBattleResultUpdateListener(listener, "未命名リスナー");
+    }
+
+    /**
+     * 戦闘結果更新リスナーを登録します
+     * 既に登録されているリスナーは重複登録されません
+     *
+     * @param listener リスナー（null不可）
+     * @param name リスナーの名前（null不可）
+     * @throws NullPointerException listenerまたはnameがnullの場合
+     */
+    public void addBattleResultUpdateListener(BattleResultUpdateListener listener, String name) {
+        Objects.requireNonNull(listener, "listener must not be null");
+        Objects.requireNonNull(name, "name must not be null");
+        NamedListener<BattleResultUpdateListener> namedListener = new NamedListener<>(listener, name);
+        if (!this.battleResultUpdateListeners.contains(namedListener)) {
+            this.battleResultUpdateListeners.add(namedListener);
+        }
+    }
+
+    /**
+     * 戦闘結果更新リスナーを解除します
+     *
+     * @param listener リスナー（null不可）
+     * @throws NullPointerException listenerがnullの場合
+     */
+    public void removeBattleResultUpdateListener(BattleResultUpdateListener listener) {
+        Objects.requireNonNull(listener, "listener must not be null");
+        this.battleResultUpdateListeners.removeIf(named -> named.getListener().equals(listener));
+    }
+
+    /**
+     * 戦闘結果更新を通知します
+     * すべてのリスナーはJavaFXアプリケーションスレッドで実行されます
+     * 現在の{@link #battleResult}をリスナーに渡します。
+     */
+    public void notifyBattleResultUpdated() {
+        this.notifyBattleResultUpdated(this.battleResult);
+    }
+
+    /**
+     * 戦闘結果更新を通知します
+     * すべてのリスナーはJavaFXアプリケーションスレッドで実行されます
+     *
+     * @param battleLog 更新された戦闘ログ（nullの可能性あり）
+     */
+    public void notifyBattleResultUpdated(BattleLog battleLog) {
+        try {
+            // JavaFXアプリケーションスレッドで実行
+            // すべてのリスナーを1回のスケジューリングで実行することで、パフォーマンスとアトミック性を確保
+            Platform.runLater(() -> {
+                for (NamedListener<BattleResultUpdateListener> namedListener : this.battleResultUpdateListeners) {
+                    try {
+                        namedListener.getListener().onBattleResultUpdated(battleLog);
+                    } catch (Exception e) {
+                        // リスナー実行中の例外をログに記録
+                        // 1つのリスナーで例外が発生しても、他のリスナーは実行される
+                        log.warn("戦闘結果更新リスナーの実行に失敗しました: リスナー名=" + namedListener.getName(), e);
+                    }
+                }
+            });
+        } catch (Exception e) {
+            // Platform.runLater()の呼び出し自体が失敗した場合
+            // （JavaFXアプリケーションが初期化されていない場合など）
+            log.warn("戦闘結果更新通知のスケジューリングに失敗しました", e);
+        }
+    }
+
+    /**
+     * 演習結果更新リスナーを登録します
+     * 既に登録されているリスナーは重複登録されません
+     *
+     * @param listener リスナー（null不可）
+     * @throws NullPointerException listenerがnullの場合
+     */
+    public void addPracticeBattleResultUpdateListener(PracticeBattleResultUpdateListener listener) {
+        this.addPracticeBattleResultUpdateListener(listener, "未命名リスナー");
+    }
+
+    /**
+     * 演習結果更新リスナーを登録します
+     * 既に登録されているリスナーは重複登録されません
+     *
+     * @param listener リスナー（null不可）
+     * @param name リスナーの名前（null不可）
+     * @throws NullPointerException listenerまたはnameがnullの場合
+     */
+    public void addPracticeBattleResultUpdateListener(PracticeBattleResultUpdateListener listener, String name) {
+        Objects.requireNonNull(listener, "listener must not be null");
+        Objects.requireNonNull(name, "name must not be null");
+        NamedListener<PracticeBattleResultUpdateListener> namedListener = new NamedListener<>(listener, name);
+        if (!this.practiceBattleResultUpdateListeners.contains(namedListener)) {
+            this.practiceBattleResultUpdateListeners.add(namedListener);
+        }
+    }
+
+    /**
+     * 演習結果更新リスナーを解除します
+     *
+     * @param listener リスナー（null不可）
+     * @throws NullPointerException listenerがnullの場合
+     */
+    public void removePracticeBattleResultUpdateListener(PracticeBattleResultUpdateListener listener) {
+        Objects.requireNonNull(listener, "listener must not be null");
+        this.practiceBattleResultUpdateListeners.removeIf(named -> named.getListener().equals(listener));
+    }
+
+    /**
+     * 演習結果更新を通知します
+     * すべてのリスナーはJavaFXアプリケーションスレッドで実行されます
+     * 現在の{@link #practiceBattleResult}をリスナーに渡します。
+     */
+    public void notifyPracticeBattleResultUpdated() {
+        this.notifyPracticeBattleResultUpdated(this.practiceBattleResult);
+    }
+
+    /**
+     * 演習結果更新を通知します
+     * すべてのリスナーはJavaFXアプリケーションスレッドで実行されます
+     *
+     * @param battleLog 更新された戦闘ログ（nullの可能性あり）
+     */
+    public void notifyPracticeBattleResultUpdated(BattleLog battleLog) {
+        try {
+            // JavaFXアプリケーションスレッドで実行
+            // すべてのリスナーを1回のスケジューリングで実行することで、パフォーマンスとアトミック性を確保
+            Platform.runLater(() -> {
+                for (NamedListener<PracticeBattleResultUpdateListener> namedListener : this.practiceBattleResultUpdateListeners) {
+                    try {
+                        namedListener.getListener().onPracticeBattleResultUpdated(battleLog);
+                    } catch (Exception e) {
+                        // リスナー実行中の例外をログに記録
+                        // 1つのリスナーで例外が発生しても、他のリスナーは実行される
+                        log.warn("演習結果更新リスナーの実行に失敗しました: リスナー名=" + namedListener.getName(), e);
+                    }
+                }
+            });
+        } catch (Exception e) {
+            // Platform.runLater()の呼び出し自体が失敗した場合
+            // （JavaFXアプリケーションが初期化されていない場合など）
+            log.warn("演習結果更新通知のスケジューリングに失敗しました", e);
+        }
+    }
 
     /**
      * アプリケーションのデフォルト設定ディレクトリから{@link AppCondition}を取得します、


### PR DESCRIPTION
#### 変更内容
「現在の戦闘」「現在の演習」について変更
変更前：１秒ごとに確認
変更後：結果が更新された際（API分析後）に、イベント発行し、イベントにより更新するように修正

#### 関連するIssue
Fixes #101

