### PR TITLE
2026/05/29 クエスト対応

### DIFF
--- a/logbook/src/main/resources/logbook/quest/1031.json
+++ b/logbook/src/main/resources/logbook/quest/1031.json
@@ -1,18 +1,18 @@
-/* [1031]【初夏限定任務】北方海域、積極戦闘哨戒作戦 */
+/* [1031]【初夏限定任務】北方海域 戦闘哨戒作戦2026 */
 {
-    "type" : "出撃",
-    "resetType" : "単発",
-    "filter" : {
+    "type": "出撃",
+    "resetType": "単発",
+    "filter": {
         "area": ["3-1", "3-2", "3-5"],
         "fleet": {
             "operator": "AND",
             "conditions": [
-                {"name": ["Gambier Bay", "Minneapolis", "Tuscaloosa", "Heywood L.E.", "大淀", "大井", "高波", "藤波", "浜波", "早波", "冬月"], "order": 1},
-                {"name": ["Gambier Bay", "Minneapolis", "Tuscaloosa", "Heywood L.E.", "大淀", "大井", "高波", "藤波", "浜波", "早波", "冬月"], "count": 2, "operator": "GE"}
+                {"name": ["Thonburi", "Tuscaloosa", "Gambier Bay", "榛名", "宗谷", "夕張", "早波", "浜波", "薄雲", "朧", "大井"], "order": 1},
+                {"name": ["Thonburi", "Tuscaloosa", "Gambier Bay", "榛名", "宗谷", "夕張", "早波", "浜波", "薄雲", "朧", "大井"], "count": 2, "operator": "GE"}
             ]
         }
     },
-    "conditions" : [
+    "conditions": [
         {"boss": true, "area": ["3-1"], "rank": ["S"], "count": 2},
         {"boss": true, "area": ["3-2"], "rank": ["S"], "count": 2},
         {"boss": true, "area": ["3-5"], "rank": ["S"], "count": 2}

--- a/logbook/src/main/resources/logbook/quest/1032.json
+++ b/logbook/src/main/resources/logbook/quest/1032.json
@@ -1,0 +1,23 @@
+/* [1032]【初夏限定任務】水上打撃部隊 作戦運用2026 */
+{
+    "type": "出撃",
+    "resetType": "単発",
+    "filter": {
+        "area": ["1-4", "2-5", "3-5", "4-5"],
+        "fleet": {
+            "description": "現在、Lv88以上の条件判定には対応していないため、ご注意ください。",
+            "operator": "AND",
+            "conditions": [
+                {"stype": ["戦艦"], "count": 2, "operator": "GE"},
+                {"stype": ["軽巡洋艦"], "count": 1, "operator": "GE"},
+                {"stype": ["駆逐艦"], "count": 2, "operator": "GE"}
+            ]
+        }
+    },
+    "conditions": [
+        {"boss": true, "area": ["1-4"], "rank": ["S"], "count": 2},
+        {"boss": true, "area": ["2-5"], "rank": ["S"], "count": 2},
+        {"boss": true, "area": ["3-5"], "rank": ["S"], "count": 2},
+        {"boss": true, "area": ["4-5"], "rank": ["S"], "count": 2}
+    ]
+}

--- a/logbook/src/main/resources/logbook/quest/1047.json
+++ b/logbook/src/main/resources/logbook/quest/1047.json
@@ -1,0 +1,20 @@
+/* [1047]「涼波改二」ラバウルより抜錨せよ！ */
+{
+    "type": "出撃",
+    "resetType": "単発",
+    "filter": {
+        "area": ["5-4", "5-5", "5-6"],
+        "fleet": {
+            "operator": "AND",
+            "conditions": [
+                {"name": ["涼波改二"], "order": 1},
+                {"name": ["鳥海", "鈴谷", "最上", "能代", "玉波", "藤波", "早波"], "count": 2, "operator": "GE"}
+            ]
+        }
+    },
+    "conditions": [
+        {"boss": true, "area": ["5-4"], "rank": ["S"], "count": 2},
+        {"boss": true, "area": ["5-5"], "rank": ["S"], "count": 2},
+        {"boss": true, "area": ["5-6"], "cell": "Z", "rank": ["S"], "count": 2}
+    ]
+}

--- a/logbook/src/main/resources/logbook/quest/953.json
+++ b/logbook/src/main/resources/logbook/quest/953.json
@@ -1,22 +1,39 @@
-/* [953]【梅雨限定任務】雨の南西諸島防衛戦！ */
+/* [953]【梅雨限定任務】雨の南西諸島防衛戦2026 */
 {
-    "type" : "出撃",
-    "resetType" : "ウィークリー",
-    "filter" : {
-        "area": ["2-1", "2-2", "2-3"],
+    "type": "出撃",
+    "resetType": "ウィークリー",
+    "filter": {
+        "area": ["1-2", "1-4", "2-1", "2-2"],
         "fleet": {
             "operator": "AND",
             "conditions": [
-                {"stype": ["巡洋艦"], "order": 1},
-                {"stype": ["駆逐艦"], "count": 1, "operator": "GE"},
-                {"stype": ["海防艦"], "count": 1, "operator": "GE"},
-                {"stype": ["水上機母艦"], "count": 1, "operator": "GE"}
+                {"stype": ["駆逐艦"], "count": 2, "operator": "GE"},
+                {
+                    "operator": "OR",
+                    "conditions": [
+                        {
+                            "operator": "AND",
+                            "conditions": [
+                                {"stype": ["海防艦"], "order": 1},
+                                {"stype": ["海防艦"], "order": 2}
+                            ]
+                        },
+                        {
+                            "operator": "AND",
+                            "conditions": [
+                                {"stype": ["水上機母艦"], "order": 1},
+                                {"stype": ["水上機母艦"], "order": 2}
+                            ]
+                        }
+                    ]
+                }
             ]
         }
     },
-    "conditions" : [
-        {"boss": true, "area": ["2-1"], "rank": ["S","A"], "count": 1},
-        {"boss": true, "area": ["2-2"], "rank": ["S","A"], "count": 1},
-        {"boss": true, "area": ["2-3"], "rank": ["S","A"], "count": 1}
+    "conditions": [
+        {"boss": true, "area": ["1-2"], "rank": ["S", "A"], "count": 1},
+        {"boss": true, "area": ["1-4"], "rank": ["S", "A"], "count": 1},
+        {"boss": true, "area": ["2-1"], "rank": ["S", "A"], "count": 1},
+        {"boss": true, "area": ["2-2"], "rank": ["S", "A"], "count": 1}
     ]
 }

--- a/logbook/src/main/resources/logbook/quest/954.json
+++ b/logbook/src/main/resources/logbook/quest/954.json
@@ -1,22 +1,22 @@
-/* [954]【梅雨拡張任務】梅雨の海上護衛強化2025 */
+/* [954]【梅雨限定任務】梅雨の海上護衛強化2026 */
 {
-    "type" : "出撃",
-    "resetType" : "ウィークリー",
-    "filter" : {
-        "area": ["1-2","1-3","1-4","1-5","1-6"],
+    "type": "出撃",
+    "resetType": "ウィークリー",
+    "filter": {
+        "area": ["1-3", "1-5", "1-6", "2-3", "7-4"],
         "fleet": {
             "operator": "AND",
             "conditions": [
-                {"stype": ["駆逐艦"], "order": 1},
-                {"stype": ["海防艦"], "count": 2, "operator": "GE"}
+                {"stype": ["軽空母"], "order": 1},
+                {"stype": ["駆逐艦"], "count": 2, "operator": "GE"}
             ]
         }
     },
-    "conditions" : [
-        {"boss": true, "area": ["1-2"], "rank": ["S"], "count": 1},
-        {"boss": true, "area": ["1-3"], "rank": ["S"], "count": 1},
-        {"boss": true, "area": ["1-4"], "rank": ["S"], "count": 1},
-        {"boss": true, "area": ["1-5"], "rank": ["S"], "count": 1},
-        {"area": ["1-6"], "rank": ["S", "A", "B", "C", "D", "E"], "cells": ["B", "D"], "count": 2}
+    "conditions": [
+        {"boss": true, "area": ["1-3"], "rank": ["S","A"], "count": 1},
+        {"boss": true, "area": ["1-5"], "rank": ["S","A"], "count": 1},
+        {"boss": true, "area": ["2-3"], "rank": ["S","A"], "count": 1},
+        {"boss": true, "area": ["7-4"], "rank": ["S","A"], "count": 1},
+        {"area": ["1-6"], "rank": ["S", "A", "B", "C", "D", "E"], "cells": ["B", "D"], "count": 3}
     ]
 }

--- a/logbook/src/main/resources/logbook/quest/955.json
+++ b/logbook/src/main/resources/logbook/quest/955.json
@@ -1,28 +1,29 @@
-/* [955]【梅雨限定月間任務】西方海域統合作戦2025 */
+/* [955]【梅雨任務拡張作戦】南方反攻望楼作戦を叩け！ */
 {
-    "type" : "出撃",
-    "resetType" : "マンスリー",
-    "filter" : {
-        "area": ["4-1", "4-2", "4-3", "4-4", "4-5"],
+    "type": "出撃",
+    "resetType": "マンスリー",
+    "filter": {
+        "area": ["5-1", "5-2", "5-3", "5-4", "5-5", "5-6"],
         "fleet": {
             "operator": "AND",
             "conditions": [
-                {"stype": ["軽空母", "正規空母", "装甲空母"], "count": 1, "operator": "GE"},
+                {"stype": ["戦艦"], "count": 1, "operator": "GE"},
                 {
                     "operator": "OR",
                     "conditions": [
                         {"stype": ["重巡洋艦", "航空巡洋艦"], "count": 2, "operator": "GE"},
-                        {"name": ["秋月", "照月", "涼月", "初月", "冬月"], "count": 2, "operator": "GE"}
+                        {"name": ["夕雲", "巻雲", "風雲", "長波", "巻波", "高波", "玉波", "涼波", "藤波", "早波", "浜波", "沖波", "岸波", "朝霜", "早霜", "秋霜", "清霜"], "count": 2, "operator": "GE"}
                     ]
                 }
             ]
         }
     },
-    "conditions" : [
-        {"boss": true, "area": ["4-1"], "rank": ["S"], "count": 1},
-        {"boss": true, "area": ["4-2"], "rank": ["S"], "count": 1},
-        {"boss": true, "area": ["4-3"], "rank": ["S"], "count": 1},
-        {"boss": true, "area": ["4-4"], "rank": ["S"], "count": 1},
-        {"boss": true, "area": ["4-5"], "rank": ["S"], "count": 1}
+    "conditions": [
+        {"boss": true, "area": ["5-1"], "rank": ["S", "A"], "count": 1},
+        {"boss": true, "area": ["5-2"], "rank": ["S", "A"], "count": 1},
+        {"boss": true, "area": ["5-3"], "rank": ["S", "A"], "count": 1},
+        {"boss": true, "area": ["5-4"], "rank": ["S", "A"], "count": 1},
+        {"boss": true, "area": ["5-5"], "rank": ["S", "A"], "count": 1},
+        {"boss": true, "area": ["5-6"], "cell": "Z", "rank": ["S", "A"], "count": 1}
     ]
 }


### PR DESCRIPTION
#### 変更内容
[953]【梅雨限定任務】雨の南西諸島防衛戦2026
[954]【梅雨限定任務】梅雨の海上護衛強化2026
[955]【梅雨任務拡張作戦】南方反攻望楼作戦を叩け！
[1031]【初夏限定任務】北方海域 戦闘哨戒作戦2026
[1032]【初夏限定任務】水上打撃部隊 作戦運用2026
[1047]「涼波改二」ラバウルより抜錨せよ！

※[1032]【初夏限定任務】水上打撃部隊 作戦運用2026について、Lv88以上の条件判定には対応していません

#### 関連するIssue
Fixes #176

