### PR TITLE
クエストにLv条件の追加

### DIFF
--- a/logbook/src/main/java/logbook/bean/AppQuestCondition.java
+++ b/logbook/src/main/java/logbook/bean/AppQuestCondition.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 import logbook.internal.AppQuestConditionLoader;
 import logbook.internal.Operator;
 import logbook.internal.QuestCollect;
+import logbook.internal.Ships;
 import logbook.internal.QuestCollect.Count;
 import logbook.internal.QuestCollect.Rank;
 import logbook.internal.ShipTypeGroup;
@@ -90,7 +91,9 @@ public class AppQuestCondition implements Predicate<QuestCollect> {
      *
      */
     @Data
-    public static class FleetCondition implements Predicate<List<ShipMst>> {
+    public static class FleetCondition implements Predicate<List<Ship>> {
+
+        private static final Set<String> LOGICAL_OPERATORS = Set.of("AND", "OR", "NAND", "NOR");
 
         /** 備考 */
         private String description;
@@ -100,6 +103,12 @@ public class AppQuestCondition implements Predicate<QuestCollect> {
 
         /** 艦名 */
         private LinkedHashSet<String> name;
+
+        /** レベル */
+        private Integer lv;
+
+        /** Lv 比較演算子（省略時 GE）。operator とは独立 */
+        private String lvOperator;
 
         /** 艦種もしくは艦名のリストに含まれないものに一致 */
         private boolean difference;
@@ -113,12 +122,12 @@ public class AppQuestCondition implements Predicate<QuestCollect> {
         /** 条件 */
         private List<FleetCondition> conditions;
 
-        /** 演算子(AND,OR,NAND,NOR,EQ(等しい),GE(以上),GT(より大きい),LE(以下),LT(より小さい),NE(等しくない)) */
+        /** 演算子(AND,OR,NAND,NOR / 隻数比較: EQ,GE,GT,LE,LT,NE)。Lv 比較には使わない */
         private String operator;
 
         @Override
-        public boolean test(List<ShipMst> ships) {
-            if (this.count == null && this.operator != null) {
+        public boolean test(List<Ship> ships) {
+            if (this.isLogicalOperator()) {
                 return this.testOperator(ships);
             } else {
                 return this.testShip(ships);
@@ -127,11 +136,15 @@ public class AppQuestCondition implements Predicate<QuestCollect> {
 
         @Override
         public String toString() {
-            if (this.count == null && this.operator != null) {
+            if (this.isLogicalOperator()) {
                 return this.toStringOperator();
             } else {
                 return this.toStringShip();
             }
+        }
+
+        private boolean isLogicalOperator() {
+            return this.count == null && this.operator != null && LOGICAL_OPERATORS.contains(this.operator);
         }
 
         /**
@@ -140,7 +153,7 @@ public class AppQuestCondition implements Predicate<QuestCollect> {
          * @param ships 艦隊
          * @return 条件に一致する場合true
          */
-        private boolean testShip(List<ShipMst> ships) {
+        private boolean testShip(List<Ship> ships) {
             if (this.count != null) {
                 // 序列の指定無効
                 int c = 0;
@@ -172,31 +185,68 @@ public class AppQuestCondition implements Predicate<QuestCollect> {
             return false;
         }
 
-        private boolean testShip0(ShipMst ship) {
+        private boolean testShip0(Ship ship) {
             if (ship == null) {
                 return false;
             }
+            ShipMst mst = Ships.shipMst(ship).orElse(null);
+            if (mst == null) {
+                return false;
+            }
+            boolean matched;
             if (this.stype != null) {
-                String stype = ship.asStype()
+                String stype = mst.asStype()
                         .map(Stype::getName)
                         .orElse(null);
 
-                //ShipTypeGroupからも判定する
+                // ShipTypeGroupからも判定する
                 boolean check = this.stype.stream()
                         .map(ShipTypeGroup::shipTypes)
                         .flatMap(List::stream)
                         .anyMatch(stype::equals);
 
-                return check || this.stype.contains(stype) || this.stype.size() > 0 && this.stype.contains("*");
-            }
-            if (this.name != null) {
+                matched = check || this.stype.contains(stype) || this.stype.size() > 0 && this.stype.contains("*");
+            } else if (this.name != null) {
+                matched = false;
                 for (String name : this.name) {
-                    if (ship.getName().startsWith(name)) {
-                        return true;
+                    if (mst.getName().startsWith(name)) {
+                        matched = true;
+                        break;
                     }
                 }
+            } else if (this.lv != null) {
+                matched = true;
+            } else {
+                return false;
             }
-            return false;
+            if (!matched) {
+                return false;
+            }
+            if (this.lv != null) {
+                return this.matchesLv(ship);
+            }
+            return true;
+        }
+
+        /**
+         * 艦娘のLvが条件を満たすか
+         *
+         * @param ship 艦娘
+         * @return 条件に一致する場合true
+         */
+        private boolean matchesLv(Ship ship) {
+            Integer shipLv = ship.getLv();
+            if (shipLv == null || this.lv == null) {
+                return false;
+            }
+            return Operator.valueOf(this.resolveLvOperator()).compare(shipLv, this.lv);
+        }
+
+        /**
+         * Lv 比較に使う演算子を返す。省略時は GE（以上）。
+         */
+        private String resolveLvOperator() {
+            return this.lvOperator != null ? this.lvOperator : "GE";
         }
 
         /**
@@ -205,8 +255,8 @@ public class AppQuestCondition implements Predicate<QuestCollect> {
          * @param ships 艦隊
          * @return 条件に一致する場合true
          */
-        private boolean testOperator(List<ShipMst> ships) {
-            Predicate<List<ShipMst>> predicate = null;
+        private boolean testOperator(List<Ship> ships) {
+            Predicate<List<Ship>> predicate = null;
             for (FleetCondition condition : this.conditions) {
                 if (predicate == null) {
                     predicate = condition;
@@ -224,6 +274,11 @@ public class AppQuestCondition implements Predicate<QuestCollect> {
 
         private String toStringShip() {
             StringBuilder sb = new StringBuilder();
+            if (this.lv != null) {
+                sb.append("Lv").append(this.lv);
+                sb.append(Operator.valueOf(this.resolveLvOperator()).toString());
+                sb.append("の");
+            }
             if (this.stype != null) {
                 sb.append(this.stype.stream().map(s -> s.equals("*") ? "任意の艦種" : s).collect(Collectors.joining("または")));
             }

--- a/logbook/src/main/java/logbook/internal/QuestCollect.java
+++ b/logbook/src/main/java/logbook/internal/QuestCollect.java
@@ -19,7 +19,7 @@ import logbook.bean.BattleLog;
 import logbook.bean.Enemy;
 import logbook.bean.MapinfoMst;
 import logbook.bean.MapinfoMstCollection;
-import logbook.bean.ShipMst;
+import logbook.bean.Ship;
 import logbook.bean.Stype;
 import logbook.internal.BattleLogs.SimpleBattleLog;
 import logbook.internal.MissionLogs.SimpleMissionLog;
@@ -124,10 +124,7 @@ public class QuestCollect {
                     battleLog = BattleLogs.read(log.getDateString());
                     if(battleLog != null) {
                         p = new PhaseState(battleLog);
-                        List<ShipMst> ships = p.getAfterFriend().stream()
-                                .filter(Objects::nonNull)
-                                .map(Ships::shipMst)
-                                .map(s -> s.orElse(null))
+                        List<Ship> ships = p.getAfterFriend().stream()
                                 .filter(Objects::nonNull)
                                 .collect(Collectors.toList());
 

--- a/logbook/src/main/resources/logbook/quest/1032.json
+++ b/logbook/src/main/resources/logbook/quest/1032.json
@@ -5,12 +5,11 @@
     "filter": {
         "area": ["1-4", "2-5", "3-5", "4-5"],
         "fleet": {
-            "description": "現在、Lv88以上の条件判定には対応していないため、ご注意ください。",
             "operator": "AND",
             "conditions": [
-                {"stype": ["戦艦"], "count": 2, "operator": "GE"},
-                {"stype": ["軽巡洋艦"], "count": 1, "operator": "GE"},
-                {"stype": ["駆逐艦"], "count": 2, "operator": "GE"}
+                {"stype": ["戦艦"], "count": 2, "operator": "GE", "lv": 88},
+                {"stype": ["軽巡洋艦"], "count": 1, "operator": "GE", "lv": 88},
+                {"stype": ["駆逐艦"], "count": 2, "operator": "GE", "lv": 88}
             ]
         }
     },

--- a/logbook/src/test/java/logbook/bean/AppQuestConditionFleetConditionLvTest.java
+++ b/logbook/src/test/java/logbook/bean/AppQuestConditionFleetConditionLvTest.java
@@ -1,0 +1,176 @@
+package logbook.bean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import logbook.internal.AppQuestConditionLoader;
+import logbook.plugin.PluginContainer;
+
+/**
+ * 艦隊条件の Lv 判定を検証する。
+ */
+class AppQuestConditionFleetConditionLvTest {
+
+    /**
+     * {@link logbook.internal.Ships} の static 初期化が {@link PluginContainer} 経由で
+     * リソースを読むため、テスト前に初期化する（{@link AppQuestDurationTest} と同様）。
+     */
+    @BeforeAll
+    static void initPluginContainer() {
+        PluginContainer.getInstance().init(Collections.emptyList());
+    }
+
+    @Test
+    void load_lvField_deserializesFromJson() throws Exception {
+        try (InputStream in = getClass().getResourceAsStream("/logbook/quest/lv_test.json")) {
+            AppQuestCondition root = AppQuestConditionLoader.load(in);
+            AppQuestCondition.FleetCondition fleet = root.getFilter().getFleet();
+            assertNotNull(fleet);
+            AppQuestCondition.FleetCondition nameLv = fleet.getConditions().get(0);
+            assertEquals(88, nameLv.getLv());
+            assertNull(nameLv.getOperator());
+            AppQuestCondition.FleetCondition stypeLv = fleet.getConditions().get(1);
+            assertEquals(50, stypeLv.getLv());
+            assertEquals(2, stypeLv.getCount());
+        }
+    }
+
+    @Test
+    void test_nameAndLv_matchesWhenLvMeetsDefaultGe() {
+        AppQuestCondition.FleetCondition condition = new AppQuestCondition.FleetCondition();
+        condition.setName(new LinkedHashSet<>(List.of("テスト艦")));
+        condition.setLv(88);
+
+        Ship ship = new Ship();
+        ship.setLv(90);
+        ship.setShipId(1);
+
+        ShipMst mst = new ShipMst();
+        mst.setId(1);
+        mst.setName("テスト艦改");
+        ShipMstCollection.get().getShipMap().put(1, mst);
+
+        assertTrue(condition.test(new ArrayList<>(List.of(ship))));
+    }
+
+    @Test
+    void test_nameAndLv_ignoresOperatorAndUsesDefaultGe() {
+        AppQuestCondition.FleetCondition condition = new AppQuestCondition.FleetCondition();
+        condition.setName(new LinkedHashSet<>(List.of("テスト艦")));
+        condition.setLv(88);
+        condition.setOperator("LE");
+
+        Ship ship = new Ship();
+        ship.setLv(90);
+        ship.setShipId(2);
+
+        ShipMst mst = new ShipMst();
+        mst.setId(2);
+        mst.setName("テスト艦");
+        ShipMstCollection.get().getShipMap().put(2, mst);
+
+        // operator は Lv に効かない。Lv88以上として Lv90 は一致する
+        assertTrue(condition.test(new ArrayList<>(List.of(ship))));
+    }
+
+    @Test
+    void test_nameAndLv_rejectsWhenLvBelowThreshold() {
+        AppQuestCondition.FleetCondition condition = new AppQuestCondition.FleetCondition();
+        condition.setName(new LinkedHashSet<>(List.of("テスト艦")));
+        condition.setLv(88);
+
+        Ship ship = new Ship();
+        ship.setLv(50);
+        ship.setShipId(2);
+
+        ShipMst mst = new ShipMst();
+        mst.setId(2);
+        mst.setName("テスト艦");
+        ShipMstCollection.get().getShipMap().put(2, mst);
+
+        assertFalse(condition.test(new ArrayList<>(List.of(ship))));
+    }
+
+    @Test
+    void toString_stypeCountAndLv_displaysLvBeforeShipType() {
+        AppQuestCondition.FleetCondition condition = new AppQuestCondition.FleetCondition();
+        condition.setStype(new LinkedHashSet<>(List.of("戦艦")));
+        condition.setCount(2);
+        condition.setOperator("GE");
+        condition.setLv(88);
+
+        assertEquals("Lv88以上の戦艦が2隻以上", condition.toString());
+    }
+
+    @Test
+    void test_countAndLv_countsOnlyShipsMatchingLv() {
+        AppQuestCondition.FleetCondition condition = new AppQuestCondition.FleetCondition();
+        condition.setStype(new LinkedHashSet<>(List.of("駆逐艦")));
+        condition.setCount(2);
+        condition.setOperator("GE");
+        condition.setLv(50);
+
+        ShipMst mst = new ShipMst();
+        mst.setId(3);
+        mst.setName("駆逐");
+        mst.setStype(2);
+        ShipMstCollection.get().getShipMap().put(3, mst);
+        Stype stype = new Stype();
+        stype.setId(2);
+        stype.setName("駆逐艦");
+        StypeCollection.get().getStypeMap().put(2, stype);
+
+        Ship high = new Ship();
+        high.setShipId(3);
+        high.setLv(60);
+        Ship low = new Ship();
+        low.setShipId(3);
+        low.setLv(40);
+
+        assertTrue(condition.test(new ArrayList<>(List.of(high, high, low))));
+        assertFalse(condition.test(new ArrayList<>(List.of(high, low, low))));
+    }
+
+    @Test
+    void test_lvOperator_le_allowsLvBelowThreshold() {
+        AppQuestCondition.FleetCondition condition = new AppQuestCondition.FleetCondition();
+        condition.setName(new LinkedHashSet<>(List.of("テスト艦")));
+        condition.setLv(10);
+        condition.setLvOperator("LE");
+
+        Ship ship = new Ship();
+        ship.setLv(5);
+        ship.setShipId(4);
+
+        ShipMst mst = new ShipMst();
+        mst.setId(4);
+        mst.setName("テスト艦");
+        ShipMstCollection.get().getShipMap().put(4, mst);
+
+        assertTrue(condition.test(new ArrayList<>(List.of(ship))));
+    }
+
+    @Test
+    void toString_lvOperator_displaysLe() {
+        AppQuestCondition.FleetCondition condition = new AppQuestCondition.FleetCondition();
+        condition.setStype(new LinkedHashSet<>(List.of("駆逐艦")));
+        condition.setCount(1);
+        condition.setOperator("GE");
+        condition.setLv(10);
+        condition.setLvOperator("LE");
+
+        assertEquals("Lv10以下の駆逐艦が1隻以上", condition.toString());
+    }
+}

--- a/logbook/src/test/resources/logbook/quest/lv_test.json
+++ b/logbook/src/test/resources/logbook/quest/lv_test.json
@@ -1,0 +1,17 @@
+/* [lv_test]Lv条件テスト用 */
+{
+    "resetType": "デイリー",
+    "filter": {
+        "area": ["5-4"],
+        "fleet": {
+            "operator": "AND",
+            "conditions": [
+                {"name": ["長波"], "lv": 88},
+                {"stype": ["駆逐艦"], "count": 2, "operator": "GE", "lv": 50}
+            ]
+        }
+    },
+    "conditions": [
+        {"boss": true, "area": ["5-4"], "rank": ["S"], "count": 1}
+    ]
+}


### PR DESCRIPTION
#### 変更内容
クエストにLv条件の追加
lv:Lv閾値
lvOperator:Lv比較演算子。省略時はGE

#### 関連するIssue
Fixes #180
