### PR TITLE
NdockCollectionのデシリアライズ時にndockSetの順序を保持する

### DIFF
--- a/logbook/src/main/java/logbook/bean/NdockCollection.java
+++ b/logbook/src/main/java/logbook/bean/NdockCollection.java
@@ -4,8 +4,6 @@ import java.io.Serializable;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
-import java.util.Set;
-
 import logbook.internal.Config;
 import lombok.Data;
 
@@ -22,7 +20,7 @@ public class NdockCollection implements Serializable {
     private Map<Integer, Ndock> ndockMap = new LinkedHashMap<>();
 
     /** 入渠中の艦娘 */
-    private Set<Integer> ndockSet = new LinkedHashSet<>();
+    private LinkedHashSet<Integer> ndockSet = new LinkedHashSet<>();
 
     /**
      * アプリケーションのデフォルト設定ディレクトリから<code>NdockCollection</code>を取得します、


### PR DESCRIPTION
#### 変更内容
Jackson3対応時の対応漏れ

#### 関連するIssue
Fixes #194  

