### PR TITLE
API レスポンスキャプチャ機能の追加

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -239,6 +239,59 @@ JSON 形式は `ContentListenerLogJson` appender を参照してください（`
 
 ---
 
+## API レスポンス記録（開発者向け）
+
+kcsapi のレスポンス JSON を `{captureDir}/segments/{日付}.jsonl.zst` に JSONL + zstd で保存します。
+`ReverseConnectHandler.invoke()` 入口の `ApiCaptureHook` が対象 URI のボディ原文を 1 回記録します（既定: すべての `/kcsapi/`）。
+POST リクエストは `request` フィールドにボディ原文、レスポンスは `response` フィールドに解凍後原文として同梱します。
+**別途インデックスファイルは持たず**、各レコードの `requestId` でアクセスログと紐づけます。
+
+### UI 表示の有効化
+
+通常の設定画面には表示されません。次のいずれかを指定してください。
+
+- 環境変数: `LOGBOOK_API_CAPTURE_UI=1`
+- システムプロパティ: `-Dlogbook.apiCapture.ui=true`
+
+### devGate（任意）
+
+リリース JAR でも UI 表示を dev モード限定にする場合:
+
+```
+-Dlogbook.apiCapture.devGate=true
+```
+
+このとき UI 表示には `-Dlogbook.dev=true` または `-Dlogbook.apiCapture.force=true` も必要です。
+
+### 記録の有効化
+
+1. 上記で UI を表示
+2. 設定 → 通信 → 「API レスポンスを記録する」を ON（初回は同意ダイアログ）
+3. 保存先を指定して OK
+4. 記録中はメインウィンドウタイトルに `[API記録中]` が付きます
+
+### 対象 URI の拡張（開発者向け）
+
+既定は `/kcsapi/` のみ。別パスを追加する場合:
+
+```java
+ApiCapturePolicy.register(ApiCaptureTargetRule.prefix("/custom-api/"));
+```
+
+ボディは原文のまま保存されます。分析時に必要なパースは `read_segments.py` 等で行います。
+
+### ログとの突合
+
+```powershell
+# アクセスログから requestId を取得
+Select-String "api_port/port" logs/access-json.log
+
+# セグメントを展開して requestId で検索
+zstd -d captures/segments/2026-07-11.jsonl.zst -c | Select-String "req-uuid-here"
+```
+
+---
+
 ## 関連ドキュメント
 
 - ビルド手順: [how-to-build.md](../how-to-build.md)

--- a/logbook/src/main/java/logbook/bean/AppConfig.java
+++ b/logbook/src/main/java/logbook/bean/AppConfig.java
@@ -260,6 +260,15 @@ public final class AppConfig implements Serializable, ConfigDefaults {
     /** store api_start2 directory */
     private String storeApiStart2Dir = "";
 
+    /** API レスポンス記録を有効にする */
+    private boolean apiCaptureEnabled = false;
+
+    /** API 記録の同意済みフラグ */
+    private boolean apiCaptureConsentAccepted = false;
+
+    /** API 記録の保存先ディレクトリ */
+    private String apiCaptureDir = "";
+
     /**
      * JSON デシリアライズ後に呼び出し、新規フィールドのバージョン差異を解消する。
      * {@link logbook.internal.Config} から読み込み時および新規生成時に適用される。

--- a/logbook/src/main/java/logbook/internal/Launcher.java
+++ b/logbook/src/main/java/logbook/internal/Launcher.java
@@ -12,6 +12,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
 import logbook.bean.AppConfig;
+import logbook.internal.capture.ApiCaptureWriter;
 import logbook.internal.gui.Main;
 import logbook.internal.metrics.LogbookBuildInfo;
 import logbook.internal.metrics.LogbookMetrics;
@@ -117,6 +118,7 @@ public final class Launcher {
      * スレッドプールの終了処理
      */
     private void exitLocalThreadPool() {
+        ApiCaptureWriter.shutdown();
         ExecutorService executor = ThreadManager.getExecutorService();
         executor.shutdownNow();
     }

--- a/logbook/src/main/java/logbook/internal/capture/ApiCaptureBodies.java
+++ b/logbook/src/main/java/logbook/internal/capture/ApiCaptureBodies.java
@@ -1,0 +1,54 @@
+package logbook.internal.capture;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import logbook.proxy.RequestMetaData;
+import logbook.proxy.ResponseMetaData;
+
+/**
+ * キャプチャ用に HTTP ボディ原文を読み取る。
+ */
+final class ApiCaptureBodies {
+
+    private ApiCaptureBodies() {
+    }
+
+    /**
+     * POST リクエストボディ原文。POST 以外または空の場合は {@code null}。
+     */
+    static String readRequestBody(RequestMetaData req) {
+        if (req == null) {
+            return null;
+        }
+        String method = req.getMethod();
+        if (method == null || !"POST".equalsIgnoreCase(method)) {
+            return null;
+        }
+        return req.getRequestBody()
+                .map(ApiCaptureBodies::readStream)
+                .filter(body -> !body.isEmpty())
+                .orElse(null);
+    }
+
+    /**
+     * レスポンスボディ原文。取得できない場合は空文字。
+     */
+    static String readResponseBody(ResponseMetaData res) {
+        if (res == null) {
+            return "";
+        }
+        return res.getResponseBody()
+                .map(ApiCaptureBodies::readStream)
+                .orElse("");
+    }
+
+    private static String readStream(InputStream stream) {
+        try (stream) {
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            return "";
+        }
+    }
+}

--- a/logbook/src/main/java/logbook/internal/capture/ApiCaptureEnvelope.java
+++ b/logbook/src/main/java/logbook/internal/capture/ApiCaptureEnvelope.java
@@ -1,0 +1,41 @@
+package logbook.internal.capture;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+
+/**
+ * API キャプチャ JSONL 1 行分のエンベロープ。
+ * <p>
+ * キュー用の {@link ApiCaptureRecord} とは分離し、永続形式のみを表す。
+ * {@code capturedAt} は {@link Instant} のまま渡し、Jackson 3 のデフォルト
+ * （ISO-8601 文字列）で書き出す。数値タイムスタンプ化しないことは
+ * {@code JsonMappersTest#mapperWritesInstantAsIso8601String} で固定する。
+ * </p>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ApiCaptureEnvelope(
+        int v,
+        String requestId,
+        Instant capturedAt,
+        String method,
+        String uriPath,
+        @JsonProperty("request") String request,
+        @JsonProperty("response") String response) {
+
+    static ApiCaptureEnvelope from(ApiCaptureRecord record, Instant capturedAt) {
+        return new ApiCaptureEnvelope(
+                1,
+                nullToEmpty(record.requestId()),
+                capturedAt,
+                nullToEmpty(record.method()),
+                nullToEmpty(record.uriPath()),
+                record.requestBody(),
+                nullToEmpty(record.responseBody()));
+    }
+
+    private static String nullToEmpty(String value) {
+        return value != null ? value : "";
+    }
+}

--- a/logbook/src/main/java/logbook/internal/capture/ApiCaptureFlushPolicy.java
+++ b/logbook/src/main/java/logbook/internal/capture/ApiCaptureFlushPolicy.java
@@ -1,0 +1,57 @@
+package logbook.internal.capture;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * エンコーダ flush / セグメント close の件数・時間判定。
+ * <p>
+ * 開発用キャプチャのため 100% 即時永続化は狙わない。
+ * 既定は encode flush: 100 件または 30 秒、segment close: 1000 件または 10 分。
+ * </p>
+ */
+final class ApiCaptureFlushPolicy {
+
+    static final ApiCaptureFlushPolicy DEFAULT = new ApiCaptureFlushPolicy(
+            100,
+            30_000L,
+            1_000,
+            600_000L);
+
+    private final int streamFlushEveryRecords;
+    private final long streamFlushIntervalMs;
+    private final int segmentCloseEveryRecords;
+    private final long segmentCloseIntervalMs;
+
+    ApiCaptureFlushPolicy(
+            int streamFlushEveryRecords,
+            long streamFlushIntervalMs,
+            int segmentCloseEveryRecords,
+            long segmentCloseIntervalMs) {
+        this.streamFlushEveryRecords = streamFlushEveryRecords;
+        this.streamFlushIntervalMs = streamFlushIntervalMs;
+        this.segmentCloseEveryRecords = segmentCloseEveryRecords;
+        this.segmentCloseIntervalMs = segmentCloseIntervalMs;
+    }
+
+    boolean shouldFlushEncoder(int recordsSinceFlush, long lastFlushNanos, long nowNanos) {
+        return recordsSinceFlush >= this.streamFlushEveryRecords
+                || intervalElapsed(lastFlushNanos, nowNanos, this.streamFlushIntervalMs);
+    }
+
+    boolean shouldCloseSegment(int recordsSinceClose, long lastCloseNanos, long nowNanos) {
+        return recordsSinceClose >= this.segmentCloseEveryRecords
+                || intervalElapsed(lastCloseNanos, nowNanos, this.segmentCloseIntervalMs);
+    }
+
+    boolean shouldFlushEncoderByTime(long lastFlushNanos, long nowNanos) {
+        return intervalElapsed(lastFlushNanos, nowNanos, this.streamFlushIntervalMs);
+    }
+
+    boolean shouldCloseSegmentByTime(long lastCloseNanos, long nowNanos) {
+        return intervalElapsed(lastCloseNanos, nowNanos, this.segmentCloseIntervalMs);
+    }
+
+    private static boolean intervalElapsed(long sinceNanos, long nowNanos, long intervalMs) {
+        return nowNanos - sinceNanos >= TimeUnit.MILLISECONDS.toNanos(intervalMs);
+    }
+}

--- a/logbook/src/main/java/logbook/internal/capture/ApiCaptureGate.java
+++ b/logbook/src/main/java/logbook/internal/capture/ApiCaptureGate.java
@@ -1,0 +1,74 @@
+package logbook.internal.capture;
+
+import logbook.bean.AppConfig;
+import logbook.internal.DevMode;
+
+/**
+ * API キャプチャ機能の UI 表示および実行可否を判定する。
+ * <p>
+ * 一般配布では {@link #UI_ENV} / {@link #UI_PROPERTY} 未設定時に UI を出さない。
+ * {@link #DEV_GATE_PROPERTY} が true のときは {@link DevMode} または {@link #FORCE_PROPERTY} が必要。
+ * </p>
+ */
+public final class ApiCaptureGate {
+
+    /** 環境変数: {@code 1} または {@code true} で UI を表示 */
+    public static final String UI_ENV = "LOGBOOK_API_CAPTURE_UI";
+
+    /** システムプロパティ: {@code true} で UI を表示 */
+    public static final String UI_PROPERTY = "logbook.apiCapture.ui";
+
+    /** システムプロパティ: {@code true} で UI 表示に dev モードまたは force を要求 */
+    public static final String DEV_GATE_PROPERTY = "logbook.apiCapture.devGate";
+
+    /** システムプロパティ: {@code true} で devGate をバイパス */
+    public static final String FORCE_PROPERTY = "logbook.apiCapture.force";
+
+    private ApiCaptureGate() {
+    }
+
+    /**
+     * 設定画面に API キャプチャ UI を表示してよいか。
+     */
+    public static boolean isUiAvailable() {
+        if (!isUiFlagSet()) {
+            return false;
+        }
+        if (Boolean.getBoolean(DEV_GATE_PROPERTY)) {
+            return DevMode.isEnabled() || Boolean.getBoolean(FORCE_PROPERTY);
+        }
+        return true;
+    }
+
+    /**
+     * devGate が有効か（メッセージ表示用）。
+     */
+    public static boolean isDevGateEnabled() {
+        return Boolean.getBoolean(DEV_GATE_PROPERTY);
+    }
+
+    /**
+     * 設定に基づき API レスポンスの記録を行うか。
+     */
+    public static boolean isCaptureActive(AppConfig config) {
+        return config.isApiCaptureEnabled()
+                && config.isApiCaptureConsentAccepted()
+                && config.getApiCaptureDir() != null
+                && !config.getApiCaptureDir().isBlank();
+    }
+
+    /**
+     * 現在の設定で記録が有効か（{@link AppConfig#get()} を参照）。
+     */
+    public static boolean isCaptureActive() {
+        return isCaptureActive(AppConfig.get());
+    }
+
+    private static boolean isUiFlagSet() {
+        String env = System.getenv(UI_ENV);
+        if (env != null && ("1".equals(env) || "true".equalsIgnoreCase(env))) {
+            return true;
+        }
+        return Boolean.getBoolean(UI_PROPERTY);
+    }
+}

--- a/logbook/src/main/java/logbook/internal/capture/ApiCaptureHook.java
+++ b/logbook/src/main/java/logbook/internal/capture/ApiCaptureHook.java
@@ -1,0 +1,38 @@
+package logbook.internal.capture;
+
+import logbook.proxy.RequestMetaData;
+import logbook.proxy.ResponseMetaData;
+
+/**
+ * プロキシ {@code invoke()} 入口から API キャプチャを行う。
+ * <p>
+ * 記録可否（{@link ApiCaptureGate}）と URI 対象（{@link ApiCapturePolicy}）の判定はここだけで行う。
+ * </p>
+ */
+public final class ApiCaptureHook {
+
+    private ApiCaptureHook() {
+    }
+
+    /**
+     * 記録が有効かつ対象 URI の場合、ボディ原文をキューへ追加する。
+     */
+    public static void captureIfNeeded(RequestMetaData request, ResponseMetaData response) {
+        if (!ApiCaptureGate.isCaptureActive()) {
+            return;
+        }
+        String uri = request.getRequestURI();
+        if (!ApiCapturePolicy.shouldCapture(uri)) {
+            return;
+        }
+        String requestBody = ApiCaptureBodies.readRequestBody(request);
+        String responseBody = ApiCaptureBodies.readResponseBody(response);
+        ApiCaptureRecord record = new ApiCaptureRecord(
+                request.getRequestId(),
+                request.getMethod(),
+                request.getUriPath(),
+                requestBody,
+                responseBody);
+        ApiCaptureWriter.enqueue(record);
+    }
+}

--- a/logbook/src/main/java/logbook/internal/capture/ApiCapturePolicy.java
+++ b/logbook/src/main/java/logbook/internal/capture/ApiCapturePolicy.java
@@ -1,0 +1,45 @@
+package logbook.internal.capture;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * API キャプチャ対象 URI の判定。
+ * <p>
+ * 既定では {@code /kcsapi/} を対象とする。
+ * {@link #register(ApiCaptureTargetRule)} でルールを追加できる。
+ * </p>
+ */
+public final class ApiCapturePolicy {
+
+    private static final List<ApiCaptureTargetRule> RULES = new CopyOnWriteArrayList<>(
+            List.of(ApiCaptureTargetRule.prefix("/kcsapi/")));
+
+    private ApiCapturePolicy() {
+    }
+
+    /**
+     * キャプチャ対象ルールを末尾に追加する。
+     */
+    public static void register(ApiCaptureTargetRule rule) {
+        RULES.add(Objects.requireNonNull(rule));
+    }
+
+    /**
+     * いずれかのルールに一致する URI をキャプチャする。
+     *
+     * @param uri リクエスト URI（クエリ含む場合あり）
+     */
+    public static boolean shouldCapture(String uri) {
+        if (uri == null) {
+            return false;
+        }
+        for (ApiCaptureTargetRule rule : RULES) {
+            if (rule.matches(uri)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/logbook/src/main/java/logbook/internal/capture/ApiCaptureRecord.java
+++ b/logbook/src/main/java/logbook/internal/capture/ApiCaptureRecord.java
@@ -1,0 +1,18 @@
+package logbook.internal.capture;
+
+/**
+ * キャプチャキューに載せる 1 件分のデータ。
+ *
+ * @param requestId アクセスログと同一の相関 ID
+ * @param method HTTP メソッド
+ * @param uriPath パスのみ（{@link logbook.internal.proxy.UriPaths#normalize} と同一規則）
+ * @param requestBody POST ボディ原文（POST 以外または空の場合は null）
+ * @param responseBody レスポンスボディ原文
+ */
+public record ApiCaptureRecord(
+        String requestId,
+        String method,
+        String uriPath,
+        String requestBody,
+        String responseBody) {
+}

--- a/logbook/src/main/java/logbook/internal/capture/ApiCaptureSegmentStore.java
+++ b/logbook/src/main/java/logbook/internal/capture/ApiCaptureSegmentStore.java
@@ -1,0 +1,204 @@
+package logbook.internal.capture;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jetty.compression.zstandard.ZstandardCompression;
+
+import logbook.internal.JsonMappers;
+import tools.jackson.core.StreamWriteFeature;
+import tools.jackson.databind.ObjectWriter;
+
+/**
+ * API キャプチャ専用の日次セグメント（JSONL + zstd）書き込み。
+ * <p>
+ * {@link ApiCaptureRecord} を {@link ApiCaptureEnvelope} に詰め、ストリームへ直書きする。
+ * 日付変更、または同一 part への書き込み件数が上限以上のときは<strong>次の書き込み</strong>で part を切り替える。
+ * part 件数はプロセス内メモリ上の累計で、セグメント close 後も同一 part では引き継ぐ。
+ * プロセス再起動時は 0 から数え直す（ディスク上の既存行は見ない）。
+ * 呼び出し側（ライター worker）から単一スレッドで使う前提。
+ * </p>
+ */
+@Slf4j
+final class ApiCaptureSegmentStore {
+
+    /** 1 セグメントあたりのレコード件数上限。到達後の次行から回転する。 */
+    static final int MAX_SEGMENT_RECORDS = 5_000;
+
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ISO_LOCAL_DATE;
+
+    /** 同一セグメントへ複数行書くため、書き込み先ストリームは閉じない */
+    private static final ObjectWriter JSON_WRITER = JsonMappers.MAPPER.writer()
+            .without(StreamWriteFeature.AUTO_CLOSE_TARGET);
+
+    private final ZstandardCompression zstandard;
+    private final Supplier<LocalDate> today;
+    private final int maxSegmentRecords;
+
+    private LocalDate currentDate;
+    private int currentPart;
+    /** 現在 part への書き込み累計（close ではリセットしない） */
+    private int partRecords;
+    private Path currentSegmentPath;
+    private OutputStream fileOutput;
+    private OutputStream compressedOutput;
+
+    ApiCaptureSegmentStore() {
+        this(LocalDate::now, MAX_SEGMENT_RECORDS);
+    }
+
+    /**
+     * @param today テスト用に日付を注入する（システム既定タイムゾーンの暦日）
+     */
+    ApiCaptureSegmentStore(Supplier<LocalDate> today) {
+        this(today, MAX_SEGMENT_RECORDS);
+    }
+
+    /**
+     * @param today テスト用に日付を注入する
+     * @param maxSegmentRecords セグメント回転の件数上限（テスト用に縮小可）
+     */
+    ApiCaptureSegmentStore(Supplier<LocalDate> today, int maxSegmentRecords) {
+        this.today = Objects.requireNonNull(today);
+        if (maxSegmentRecords <= 0) {
+            throw new IllegalArgumentException("maxSegmentRecords must be positive");
+        }
+        this.maxSegmentRecords = maxSegmentRecords;
+        try {
+            this.zstandard = new ZstandardCompression();
+            this.zstandard.start();
+        } catch (Exception e) {
+            throw new IllegalStateException("Zstandard の初期化に失敗しました", e);
+        }
+    }
+
+    /**
+     * 必要ならセグメントを開き、レコードを 1 行 JSONL として書き込む。
+     *
+     * @return この呼び出しで新規セグメントを開いた場合は {@code true}
+     */
+    boolean append(Path captureDir, ApiCaptureRecord record) throws Exception {
+        Objects.requireNonNull(captureDir);
+        Objects.requireNonNull(record);
+        Files.createDirectories(captureDir.resolve("segments"));
+        boolean opened = openIfNeeded(captureDir);
+        ApiCaptureEnvelope envelope = ApiCaptureEnvelope.from(record, Instant.now());
+        JSON_WRITER.writeValue(this.compressedOutput, envelope);
+        this.compressedOutput.write('\n');
+        this.partRecords++;
+        return opened;
+    }
+
+    boolean isOpen() {
+        return this.compressedOutput != null;
+    }
+
+    void flushEncoderQuietly() {
+        if (this.compressedOutput == null) {
+            return;
+        }
+        try {
+            this.compressedOutput.flush();
+        } catch (IOException e) {
+            log.debug("APIキャプチャエンコーダの flush に失敗しました", e);
+        }
+    }
+
+    void closeQuietly() {
+        if (this.compressedOutput != null) {
+            try {
+                this.compressedOutput.close();
+            } catch (IOException e) {
+                log.debug("APIキャプチャセグメントのクローズに失敗しました", e);
+            }
+        }
+        this.compressedOutput = null;
+        this.fileOutput = null;
+        this.currentSegmentPath = null;
+        // partRecords は維持（同一 part への再 APPEND 時に件数天井へ引き継ぐ）
+    }
+
+    Path currentSegmentPath() {
+        return this.currentSegmentPath;
+    }
+
+    /**
+     * 日付変更、または同一 part の累計件数が上限以上ならセグメントを開き直す。
+     *
+     * @return 新規にセグメントを開いた場合は {@code true}
+     */
+    private boolean openIfNeeded(Path captureDir) throws Exception {
+        LocalDate date = this.today.get();
+        if (date == null) {
+            date = LocalDate.now(ZoneId.systemDefault());
+        }
+        if (this.compressedOutput != null) {
+            if (date.equals(this.currentDate)
+                    && this.partRecords < this.maxSegmentRecords) {
+                return false;
+            }
+            if (date.equals(this.currentDate)) {
+                this.currentPart++;
+            } else {
+                this.currentPart = 0;
+                this.currentDate = date;
+            }
+            closeQuietly();
+            this.partRecords = 0;
+        } else if (this.currentDate == null || !date.equals(this.currentDate)) {
+            this.currentDate = date;
+            this.currentPart = 0;
+            this.partRecords = 0;
+        }
+        Path segmentsDir = captureDir.resolve("segments");
+        String baseName = DATE_FORMAT.format(this.currentDate);
+        if (this.currentPart <= 0) {
+            this.currentPart = findLatestPart(segmentsDir, baseName);
+        }
+        this.currentSegmentPath = segmentsDir.resolve(partFileName(baseName, this.currentPart));
+        boolean append = Files.exists(this.currentSegmentPath);
+        this.fileOutput = Files.newOutputStream(
+                this.currentSegmentPath,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.WRITE,
+                append ? StandardOpenOption.APPEND : StandardOpenOption.TRUNCATE_EXISTING);
+        this.compressedOutput = this.zstandard.newEncoderOutputStream(
+                this.fileOutput,
+                this.zstandard.getDefaultEncoderConfig());
+        return true;
+    }
+
+    static int findLatestPart(Path segmentsDir, String baseName) throws IOException {
+        Path first = segmentsDir.resolve(baseName + ".jsonl.zst");
+        if (!Files.exists(first)) {
+            return 1;
+        }
+        int latest = 1;
+        int part = 2;
+        while (true) {
+            Path candidate = segmentsDir.resolve(baseName + ".part" + part + ".jsonl.zst");
+            if (!Files.exists(candidate)) {
+                return latest;
+            }
+            latest = part;
+            part++;
+        }
+    }
+
+    static String partFileName(String baseName, int part) {
+        if (part <= 1) {
+            return baseName + ".jsonl.zst";
+        }
+        return baseName + ".part" + part + ".jsonl.zst";
+    }
+}

--- a/logbook/src/main/java/logbook/internal/capture/ApiCaptureTargetRule.java
+++ b/logbook/src/main/java/logbook/internal/capture/ApiCaptureTargetRule.java
@@ -1,0 +1,25 @@
+package logbook.internal.capture;
+
+/**
+ * API キャプチャ対象 URI の判定ルール。
+ */
+@FunctionalInterface
+public interface ApiCaptureTargetRule {
+
+    /**
+     * 指定 URI がキャプチャ対象か。
+     *
+     * @param uri リクエスト URI（クエリ含む場合あり）
+     */
+    boolean matches(String uri);
+
+    /**
+     * パス prefix 一致ルール。
+     */
+    static ApiCaptureTargetRule prefix(String prefix) {
+        if (prefix == null || prefix.isEmpty()) {
+            throw new IllegalArgumentException("prefix must not be blank");
+        }
+        return uri -> uri != null && uri.startsWith(prefix);
+    }
+}

--- a/logbook/src/main/java/logbook/internal/capture/ApiCaptureTitles.java
+++ b/logbook/src/main/java/logbook/internal/capture/ApiCaptureTitles.java
@@ -1,0 +1,27 @@
+package logbook.internal.capture;
+
+import logbook.bean.AppConfig;
+import logbook.internal.DevMode;
+import logbook.internal.Version;
+
+/**
+ * ウィンドウタイトル等の API キャプチャ状態表示。
+ */
+public final class ApiCaptureTitles {
+
+    private static final String RECORDING_SUFFIX = " [API記録中]";
+
+    private ApiCaptureTitles() {
+    }
+
+    /**
+     * 航海日誌のメインウィンドウタイトルを返す。
+     */
+    public static String mainWindowTitle() {
+        String base = "航海日誌 " + DevMode.formatVersionDisplay(Version.getCurrent());
+        if (ApiCaptureGate.isCaptureActive(AppConfig.get())) {
+            return base + RECORDING_SUFFIX;
+        }
+        return base;
+    }
+}

--- a/logbook/src/main/java/logbook/internal/capture/ApiCaptureWriteService.java
+++ b/logbook/src/main/java/logbook/internal/capture/ApiCaptureWriteService.java
@@ -1,0 +1,314 @@
+package logbook.internal.capture;
+
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+
+import logbook.bean.AppConfig;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * API キャプチャの非同期書き込み本体。
+ * <p>
+ * キュー・worker・ライフサイクルと flush ポリシー適用を担当する。
+ * セグメント I/O は {@link ApiCaptureSegmentStore} に委譲する。
+ * テストではインスタンスを直接生成する。本番は {@link ApiCaptureWriter} が保持する。
+ * </p>
+ */
+@Slf4j
+final class ApiCaptureWriteService {
+
+    /** worker のキュー待ちタイムアウト（ミリ秒） */
+    private static final long POLL_TIMEOUT_MS = 500L;
+
+    /** 命令完了待ちタイムアウト（ミリ秒） */
+    private static final long COMMAND_TIMEOUT_MS = 5_000L;
+
+    private final Supplier<Boolean> captureActive;
+    private final Supplier<Path> captureDir;
+    private final ApiCaptureFlushPolicy flushPolicy;
+    private final LongSupplier nanoTime;
+    private final ApiCaptureSegmentStore segmentStore;
+
+    private final Object lifecycleLock = new Object();
+    private final LinkedBlockingQueue<WriterCommand> queue = new LinkedBlockingQueue<>();
+    private final AtomicBoolean accepting = new AtomicBoolean(true);
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private Thread worker;
+
+    private int recordsSinceStreamFlush;
+    private int recordsSinceSegmentClose;
+    private long lastStreamFlushNanos;
+    private long lastSegmentCloseNanos;
+
+    ApiCaptureWriteService(
+            Supplier<Boolean> captureActive,
+            Supplier<Path> captureDir,
+            ApiCaptureFlushPolicy flushPolicy,
+            LongSupplier nanoTime) {
+        this(captureActive, captureDir, flushPolicy, nanoTime, new ApiCaptureSegmentStore());
+    }
+
+    ApiCaptureWriteService(
+            Supplier<Boolean> captureActive,
+            Supplier<Path> captureDir,
+            ApiCaptureFlushPolicy flushPolicy,
+            LongSupplier nanoTime,
+            ApiCaptureSegmentStore segmentStore) {
+        this.captureActive = Objects.requireNonNull(captureActive);
+        this.captureDir = Objects.requireNonNull(captureDir);
+        this.flushPolicy = Objects.requireNonNull(flushPolicy);
+        this.nanoTime = Objects.requireNonNull(nanoTime);
+        this.segmentStore = Objects.requireNonNull(segmentStore);
+        startWorker();
+    }
+
+    /**
+     * 本番用インスタンスを生成する。
+     */
+    static ApiCaptureWriteService createDefault() {
+        return new ApiCaptureWriteService(
+                ApiCaptureGate::isCaptureActive,
+                () -> Path.of(AppConfig.get().getApiCaptureDir()),
+                ApiCaptureFlushPolicy.DEFAULT,
+                System::nanoTime);
+    }
+
+    private void startWorker() {
+        this.worker = Thread.ofVirtual().name("api-capture-writer").start(this::runLoop);
+    }
+
+    boolean enqueue(ApiCaptureRecord record) {
+        Objects.requireNonNull(record);
+        synchronized (this.lifecycleLock) {
+            if (!this.accepting.get()) {
+                log.atDebug()
+                        .setMessage(() -> "APIキャプチャの受付停止中のためレコードを破棄しました: uriPath="
+                                + record.uriPath())
+                        .log();
+                return false;
+            }
+            ensureWorkerStartedLocked();
+            this.queue.offer(new RecordCommand(record));
+            return true;
+        }
+    }
+
+    void flush() {
+        CountDownLatch done = new CountDownLatch(1);
+        synchronized (this.lifecycleLock) {
+            if (!this.accepting.get()) {
+                return;
+            }
+            ensureWorkerStartedLocked();
+            this.queue.offer(new FlushCommand(done));
+        }
+        awaitCommand(done, "flush");
+    }
+
+    void shutdown() {
+        CountDownLatch done = new CountDownLatch(1);
+        synchronized (this.lifecycleLock) {
+            if (!this.accepting.compareAndSet(true, false)) {
+                return;
+            }
+            ensureWorkerStartedLocked();
+            this.queue.offer(new ShutdownCommand(done));
+        }
+        awaitCommand(done, "shutdown");
+    }
+
+    private static void awaitCommand(CountDownLatch done, String commandName) {
+        try {
+            if (!done.await(COMMAND_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                log.warn("APIキャプチャの {} がタイムアウトしました", commandName);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void ensureWorkerStartedLocked() {
+        if (!this.running.get() && (this.worker == null || !this.worker.isAlive())) {
+            startWorker();
+        }
+    }
+
+    private void runLoop() {
+        this.running.set(true);
+        try {
+            while (true) {
+                WriterCommand command = this.queue.poll(POLL_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+                if (command != null) {
+                    if (processCommand(command)) {
+                        break;
+                    }
+                    continue;
+                }
+                maybePeriodicMaintenance();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            log.warn("APIキャプチャライタースレッドで例外が発生しました", e);
+        } finally {
+            releasePendingCommands();
+            this.segmentStore.closeQuietly();
+            this.running.set(false);
+        }
+    }
+
+    private boolean processCommand(WriterCommand command) {
+        return switch (command) {
+            case RecordCommand(var record) -> {
+                writeRecord(record);
+                yield false;
+            }
+            case FlushCommand(var done) -> {
+                completeFlush(done);
+                yield false;
+            }
+            case ShutdownCommand(var done) -> {
+                completeShutdown(done);
+                yield true;
+            }
+        };
+    }
+
+    private void completeFlush(CountDownLatch done) {
+        try {
+            this.segmentStore.closeQuietly();
+            resetFlushCounters();
+        } finally {
+            done.countDown();
+        }
+    }
+
+    private void completeShutdown(CountDownLatch done) {
+        try {
+            this.segmentStore.closeQuietly();
+            resetFlushCounters();
+        } finally {
+            done.countDown();
+        }
+    }
+
+    /**
+     * worker 異常終了時にキューへ残った命令を処理する。
+     * <p>
+     * 正常終了は {@link ShutdownCommand} でセグメントを閉じてからループを抜けるため、
+     * ここに到達するのは例外等による異常終了時のみである。
+     * </p>
+     * <ul>
+     * <li>{@link FlushCommand} / {@link ShutdownCommand}: {@link CountDownLatch#countDown()} のみ。
+     *     呼び出し側の待ちを解放する（セグメント close は直後の {@code finally}）。</li>
+     * <li>{@link RecordCommand}: 未書き込みのため破棄する。</li>
+     * </ul>
+     */
+    private void releasePendingCommands() {
+        int releasedWaiters = 0;
+        int droppedRecords = 0;
+        WriterCommand pending;
+        while ((pending = this.queue.poll()) != null) {
+            switch (pending) {
+                case FlushCommand(var done) -> {
+                    done.countDown();
+                    releasedWaiters++;
+                }
+                case ShutdownCommand(var done) -> {
+                    done.countDown();
+                    releasedWaiters++;
+                }
+                case RecordCommand ignored -> droppedRecords++;
+            }
+        }
+        if (releasedWaiters > 0 || droppedRecords > 0) {
+            log.warn(
+                    "APIキャプチャ worker 異常終了: キュー残りを処理しました"
+                            + " (待ち解放={}, 未書き込みレコード破棄={})",
+                    releasedWaiters,
+                    droppedRecords);
+        }
+    }
+
+    private void writeRecord(ApiCaptureRecord record) {
+        if (!Boolean.TRUE.equals(this.captureActive.get())) {
+            return;
+        }
+        try {
+            if (this.segmentStore.append(this.captureDir.get(), record)) {
+                markSegmentOpened();
+            }
+            onRecordWritten();
+        } catch (Exception e) {
+            log.warn("APIキャプチャの保存に失敗しました: uriPath={}", record.uriPath(), e);
+            this.segmentStore.closeQuietly();
+            resetFlushCounters();
+        }
+    }
+
+    private void onRecordWritten() {
+        this.recordsSinceStreamFlush++;
+        this.recordsSinceSegmentClose++;
+        long now = this.nanoTime.getAsLong();
+        if (this.flushPolicy.shouldFlushEncoder(
+                this.recordsSinceStreamFlush, this.lastStreamFlushNanos, now)) {
+            this.segmentStore.flushEncoderQuietly();
+            this.recordsSinceStreamFlush = 0;
+            this.lastStreamFlushNanos = this.nanoTime.getAsLong();
+        }
+        if (this.flushPolicy.shouldCloseSegment(
+                this.recordsSinceSegmentClose, this.lastSegmentCloseNanos, now)) {
+            this.segmentStore.closeQuietly();
+            resetFlushCounters();
+            this.lastSegmentCloseNanos = this.nanoTime.getAsLong();
+        }
+    }
+
+    private void maybePeriodicMaintenance() {
+        if (!this.segmentStore.isOpen()) {
+            return;
+        }
+        long now = this.nanoTime.getAsLong();
+        if (this.flushPolicy.shouldFlushEncoderByTime(this.lastStreamFlushNanos, now)) {
+            this.segmentStore.flushEncoderQuietly();
+            this.recordsSinceStreamFlush = 0;
+            this.lastStreamFlushNanos = this.nanoTime.getAsLong();
+        }
+        if (this.flushPolicy.shouldCloseSegmentByTime(this.lastSegmentCloseNanos, now)) {
+            this.segmentStore.closeQuietly();
+            resetFlushCounters();
+            this.lastSegmentCloseNanos = this.nanoTime.getAsLong();
+        }
+    }
+
+    private void markSegmentOpened() {
+        long now = this.nanoTime.getAsLong();
+        this.lastStreamFlushNanos = now;
+        this.lastSegmentCloseNanos = now;
+        this.recordsSinceStreamFlush = 0;
+        this.recordsSinceSegmentClose = 0;
+    }
+
+    private void resetFlushCounters() {
+        this.recordsSinceStreamFlush = 0;
+        this.recordsSinceSegmentClose = 0;
+    }
+
+    private sealed interface WriterCommand permits RecordCommand, FlushCommand, ShutdownCommand {
+    }
+
+    private record RecordCommand(ApiCaptureRecord record) implements WriterCommand {
+    }
+
+    private record FlushCommand(CountDownLatch done) implements WriterCommand {
+    }
+
+    private record ShutdownCommand(CountDownLatch done) implements WriterCommand {
+    }
+}

--- a/logbook/src/main/java/logbook/internal/capture/ApiCaptureWriter.java
+++ b/logbook/src/main/java/logbook/internal/capture/ApiCaptureWriter.java
@@ -1,0 +1,48 @@
+package logbook.internal.capture;
+
+/**
+ * API キャプチャを JSONL + zstd 日次セグメントへ非同期書き込みする（本番向けファサード）。
+ * <p>
+ * 実体は {@link ApiCaptureWriteService}。ファイル操作は worker スレッドのみが行う。
+ * {@link #flush()} / {@link #shutdown()} はキューへ命令を投入し、
+ * 先行レコードの処理完了後にセグメントを閉じる。
+ * </p>
+ */
+public final class ApiCaptureWriter {
+
+    private static final ApiCaptureWriteService INSTANCE = ApiCaptureWriteService.createDefault();
+
+    private ApiCaptureWriter() {
+    }
+
+    /**
+     * キャプチャレコードをキューに追加する。
+     * <p>
+     * 呼び出し元で {@link ApiCaptureGate#isCaptureActive()} を確認済みであること。
+     * 非同期書き込み時に設定 OFF になった場合は破棄する。
+     * shutdown 開始後は受け付けず {@code false} を返す。
+     * </p>
+     *
+     * @return キューに載せた場合 {@code true}
+     */
+    public static boolean enqueue(ApiCaptureRecord record) {
+        return INSTANCE.enqueue(record);
+    }
+
+    /**
+     * 呼び出し時点までにキューへ投入済みのレコードを書き切り、セグメントを閉じる。
+     * <p>
+     * 受付は継続する。アプリ終了時は {@link #shutdown()} を使う。
+     * </p>
+     */
+    public static void flush() {
+        INSTANCE.flush();
+    }
+
+    /**
+     * 受付を停止し、キュー内の先行レコードをすべて書き込んでからセグメントを閉じ、worker を終了する。
+     */
+    public static void shutdown() {
+        INSTANCE.shutdown();
+    }
+}

--- a/logbook/src/main/java/logbook/internal/gui/ConfigController.java
+++ b/logbook/src/main/java/logbook/internal/gui/ConfigController.java
@@ -37,6 +37,7 @@ import javafx.scene.control.TextField;
 import javafx.scene.control.ToggleGroup;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.layout.GridPane;
+import javafx.scene.layout.VBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.text.TextFlow;
 import javafx.stage.DirectoryChooser;
@@ -56,6 +57,7 @@ import logbook.internal.Config;
 import logbook.internal.LoggerHolder;
 import logbook.internal.ShipImageCacheStrategy;
 import logbook.internal.ThreadManager;
+import logbook.internal.capture.ApiCaptureGate;
 import logbook.internal.ToStringConverter;
 import logbook.internal.Tuple;
 import logbook.internal.Tuple.Pair;
@@ -372,6 +374,21 @@ public class ConfigController extends WindowController {
     @FXML
     private Button storeApiStart2DirRef;
 
+    @FXML
+    private VBox apiCapturePane;
+
+    @FXML
+    private CheckBox apiCaptureEnabled;
+
+    @FXML
+    private TextField apiCaptureDir;
+
+    @FXML
+    private Button apiCaptureDirRef;
+
+    /** セッション中に API 記録の同意ダイアログを通過したか */
+    private boolean apiCaptureConsentAcceptedInSession;
+
     /** FFmpeg 実行ファイル */
     @FXML
     private TextField ffmpegPath;
@@ -586,8 +603,16 @@ public class ConfigController extends WindowController {
         this.usePlugin.setSelected(conf.isUsePlugin());
         this.storeInternal.setSelected(conf.isStoreApiStart2());
         this.storeApiStart2.setSelected(conf.isStoreApiStart2());
-        this.storeApiStart2Dir.setText(conf.getStoreApiStart2Dir());
+        this.storeApiStart2Dir.setText(conf.getStoreApiStart2Dir() != null ? conf.getStoreApiStart2Dir() : "");
         this.storeInternal.getOnAction().handle(new ActionEvent());
+        this.apiCaptureConsentAcceptedInSession = conf.isApiCaptureConsentAccepted();
+        if (ApiCaptureGate.isUiAvailable()) {
+            this.apiCaptureEnabled.setSelected(conf.isApiCaptureEnabled());
+            this.apiCaptureDir.setText(conf.getApiCaptureDir() != null ? conf.getApiCaptureDir() : "");
+        } else {
+            this.apiCapturePane.setVisible(false);
+            this.apiCapturePane.setManaged(false);
+        }
 
         this.pluginName.setCellValueFactory(new PropertyValueFactory<>("name"));
         this.pluginVendor.setCellValueFactory(new PropertyValueFactory<>("vendor"));
@@ -707,13 +732,23 @@ public class ConfigController extends WindowController {
         conf.setProxyPort(this.toInt(this.proxyPort.getText()));
         conf.setStoreApiStart2(this.storeApiStart2.isSelected());
         conf.setStoreApiStart2Dir(this.storeApiStart2Dir.getText());
-        
+        if (ApiCaptureGate.isUiAvailable()) {
+            conf.setApiCaptureEnabled(this.apiCaptureEnabled.isSelected());
+            if (conf.isApiCaptureEnabled()) {
+                conf.setApiCaptureConsentAccepted(
+                        conf.isApiCaptureConsentAccepted() || this.apiCaptureConsentAcceptedInSession);
+            }
+            conf.setApiCaptureDir(this.apiCaptureDir.getText());
+        }
+
         conf.setFfmpegPath(this.ffmpegPath.getText());
         conf.setFfmpegArgs(this.ffmpegArgs.getText());
         conf.setFfmpegExt(this.ffmpegExt.getText());
         conf.setUsePlugin(this.usePlugin.isSelected());
 
         this.bouyomiChanStore();
+
+        Main.refreshMainWindowTitle();
 
         ThreadManager.getExecutorService()
                 .execute(Config.getDefault()::store);
@@ -889,6 +924,47 @@ public class ConfigController extends WindowController {
                 .filter(File::exists)
                 .map(File::getAbsolutePath)
                 .ifPresent(this.storeApiStart2Dir::setText);
+    }
+
+    @FXML
+    void apiCaptureEnabledChanged(ActionEvent event) {
+        if (!this.apiCaptureEnabled.isSelected()) {
+            return;
+        }
+        AppConfig conf = AppConfig.get();
+        if (conf.isApiCaptureConsentAccepted() || this.apiCaptureConsentAcceptedInSession) {
+            return;
+        }
+        if (!this.confirmApiCaptureConsent()) {
+            this.apiCaptureEnabled.setSelected(false);
+            return;
+        }
+        this.apiCaptureConsentAcceptedInSession = true;
+    }
+
+    @FXML
+    void selectApiCaptureDir(ActionEvent event) {
+        DirectoryChooser dc = new DirectoryChooser();
+        dc.setTitle("API 記録の保存先");
+        if (Files.exists(Paths.get(this.apiCaptureDir.getText()))) {
+            dc.setInitialDirectory(Paths.get(this.apiCaptureDir.getText()).toAbsolutePath().toFile());
+        }
+        Optional.ofNullable(dc.showDialog(this.getWindow()))
+                .filter(File::exists)
+                .map(File::getAbsolutePath)
+                .ifPresent(this.apiCaptureDir::setText);
+    }
+
+    private boolean confirmApiCaptureConsent() {
+        Alert alert = new Alert(AlertType.CONFIRMATION);
+        alert.initOwner(this.getWindow());
+        alert.setTitle("API 記録の確認");
+        alert.setHeaderText("API レスポンスを記録します");
+        alert.setContentText("""
+                ゲーム API のレスポンス JSON が指定ディレクトリへ保存されます。
+                個人情報が含まれる可能性があります。記録中はウィンドウタイトルに [API記録中] と表示されます。
+                requestId でアクセスログと紐づけできます。続行しますか？""");
+        return alert.showAndWait().filter(ButtonType.OK::equals).isPresent();
     }
 
     /**

--- a/logbook/src/main/java/logbook/internal/gui/Main.java
+++ b/logbook/src/main/java/logbook/internal/gui/Main.java
@@ -20,8 +20,7 @@ import javafx.stage.WindowEvent;
 import logbook.bean.AppConfig;
 import logbook.bean.WindowLocation;
 import logbook.internal.CheckUpdate;
-import logbook.internal.DevMode;
-import logbook.internal.Version;
+import logbook.internal.capture.ApiCaptureTitles;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -67,7 +66,7 @@ public class Main extends Application implements SystemSleepListener {
         // 最前面に表示する
         stage.setAlwaysOnTop(AppConfig.get().isOnTop());
 
-        stage.setTitle("航海日誌 " + DevMode.formatVersionDisplay(Version.getCurrent()));
+        stage.setTitle(ApiCaptureTitles.mainWindowTitle());
 
         stage.addEventHandler(WindowEvent.WINDOW_CLOSE_REQUEST, e -> {
             if (AppConfig.get().isCheckDoit()) {
@@ -149,6 +148,18 @@ public class Main extends Application implements SystemSleepListener {
      */
     public static Stage getPrimaryStage() {
         return mainController != null ? mainController.getWindow() : null;
+    }
+
+    /**
+     * メインウィンドウのタイトルを現在の設定に合わせて更新する。
+     */
+    public static void refreshMainWindowTitle() {
+        Platform.runLater(() -> {
+            Stage stage = getPrimaryStage();
+            if (stage != null) {
+                stage.setTitle(ApiCaptureTitles.mainWindowTitle());
+            }
+        });
     }
 
     public static WindowController getMainController() {

--- a/logbook/src/main/java/logbook/internal/proxy/CaptureHolder2.java
+++ b/logbook/src/main/java/logbook/internal/proxy/CaptureHolder2.java
@@ -28,6 +28,7 @@ public class CaptureHolder2 {
     public static class HttpRequest {
         private String method;
         private String uri;
+        private String uriPath;
         private String version;
         private final Map<String, String> headers = new LinkedHashMap<>();
         private final List<byte[]> bodyChunks = new ArrayList<>();
@@ -36,6 +37,7 @@ public class CaptureHolder2 {
         public void setRequestLine(String method, String uri, String version) {
             this.method = method;
             this.uri = uri;
+            this.uriPath = UriPaths.normalize(uri);
             this.version = version;
         }
         
@@ -57,7 +59,14 @@ public class CaptureHolder2 {
         public String getUri() {
             return uri;
         }
-        
+
+        /**
+         * ログ・集計用パス（クエリ・フラグメント除外）。
+         */
+        public String getUriPath() {
+            return uriPath;
+        }
+
         public String getVersion() {
             return version;
         }
@@ -119,6 +128,7 @@ public class CaptureHolder2 {
         public void clear() {
             method = null;
             uri = null;
+            uriPath = null;
             version = null;
             headers.clear();
             bodyChunks.clear();

--- a/logbook/src/main/java/logbook/internal/proxy/ProxyAccessLogger.java
+++ b/logbook/src/main/java/logbook/internal/proxy/ProxyAccessLogger.java
@@ -2,7 +2,6 @@ package logbook.internal.proxy;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -225,7 +224,7 @@ public final class ProxyAccessLogger
         context.put(MDC_CLIENT_PORT, String.valueOf(clientAddress.port()));
         context.put(MDC_METHOD, nullToDefault(request.getMethod(), "UNKNOWN"));
         context.put(MDC_URI, uri);
-        context.put(MDC_URI_PATH, extractUriPath(uri));
+        context.put(MDC_URI_PATH, nullToDefault(request.getUriPath(), "/"));
         context.put(MDC_REQUEST_ID, nullToEmpty(transaction.getRequestId()));
         context.put(MDC_HOST, nullToEmpty(request.getHeaderIgnoreCase("Host")));
         context.put(MDC_STATUS, String.valueOf(response.getStatus()));
@@ -253,56 +252,6 @@ public final class ProxyAccessLogger
             return System.currentTimeMillis() - requestStartTime;
         }
         return System.currentTimeMillis() - connectionStartTimeMillis;
-    }
-
-    /**
-     * URIからクエリ文字列を除いたパス部分を抽出する（Grafana/Loki集計用）。
-     *
-     * @param uri リクエストURI
-     * @return パス部分
-     */
-    static String extractUriPath(String uri)
-    {
-        if (uri == null || uri.isEmpty())
-        {
-            return "/";
-        }
-
-        if (uri.startsWith("/") || !uri.contains("://"))
-        {
-            return stripQueryAndFragment(uri);
-        }
-
-        try
-        {
-            String path = URI.create(uri).getPath();
-            if (path == null || path.isEmpty())
-            {
-                return "/";
-            }
-            return path;
-        }
-        catch (IllegalArgumentException e)
-        {
-            return stripQueryAndFragment(uri);
-        }
-    }
-
-    private static String stripQueryAndFragment(String uri)
-    {
-        int end = uri.length();
-        int queryIndex = uri.indexOf('?');
-        if (queryIndex >= 0)
-        {
-            end = queryIndex;
-        }
-        int fragmentIndex = uri.indexOf('#');
-        if (fragmentIndex >= 0 && fragmentIndex < end)
-        {
-            end = fragmentIndex;
-        }
-        String path = uri.substring(0, end);
-        return path.isEmpty() ? "/" : path;
     }
 
     private static TimingMetrics resolveTimingMetrics(CaptureHolder2.HttpTransaction transaction, long elapsedMs)

--- a/logbook/src/main/java/logbook/internal/proxy/ProxyContentListenerLogger.java
+++ b/logbook/src/main/java/logbook/internal/proxy/ProxyContentListenerLogger.java
@@ -164,10 +164,9 @@ public final class ProxyContentListenerLogger
         Outcome outcome,
         String errorDetail)
     {
-        String uri = nullToDefault(request.getRequestURI(), "/");
         Map<String, String> context = new HashMap<>();
         context.put(MDC_METHOD, nullToDefault(request.getMethod(), "UNKNOWN"));
-        context.put(MDC_URI_PATH, ProxyAccessLogger.extractUriPath(uri));
+        context.put(MDC_URI_PATH, nullToDefault(request.getUriPath(), "/"));
         context.put(ProxyAccessLogger.MDC_REQUEST_ID, nullToEmpty(request.getRequestId()));
         context.put(MDC_LAYER, layer.value());
         context.put(MDC_HANDLER_CLASS, handlerClass);

--- a/logbook/src/main/java/logbook/internal/proxy/ReverseConnectHandler.java
+++ b/logbook/src/main/java/logbook/internal/proxy/ReverseConnectHandler.java
@@ -48,6 +48,7 @@ import org.eclipse.jetty.client.HttpClient;
 
 import logbook.bean.AppConfig;
 import logbook.internal.ThreadManager;
+import logbook.internal.capture.ApiCaptureHook;
 import logbook.plugin.PluginServices;
 import logbook.proxy.ContentListenerSpi;
 import logbook.proxy.RequestMetaData;
@@ -1538,6 +1539,8 @@ public class ReverseConnectHandler extends Handler.Wrapper
          */
         private void invoke(RequestMetaDataWrapper baseReq, ResponseMetaDataWrapper baseRes)
         {
+            ApiCaptureHook.captureIfNeeded(baseReq, baseRes);
+
             // Get content listeners (validated in onSuccess(), guaranteed non-empty here)
             List<ContentListenerSpi> listeners = ReverseConnectHandler.getContentListeners();
             
@@ -2784,6 +2787,7 @@ public class ReverseConnectHandler extends Handler.Wrapper
         private String contentType;
         private String method;
         private String requestURI;
+        private String uriPath;
         private String queryString;
         private String requestId = "";
         private Map<String, String> headers = new LinkedHashMap<>();
@@ -2798,6 +2802,7 @@ public class ReverseConnectHandler extends Handler.Wrapper
         {
             this.method = httpRequest.getMethod();
             this.requestURI = httpRequest.getUri();
+            this.uriPath = httpRequest.getUriPath();
             this.headers = new LinkedHashMap<>(httpRequest.getHeaders());
             this.contentType = httpRequest.getContentType();
             
@@ -2825,6 +2830,7 @@ public class ReverseConnectHandler extends Handler.Wrapper
             this.method = req.getMethod();
             this.requestURI = req.getHttpURI().getPath();
             this.queryString = req.getHttpURI().getQuery();
+            this.uriPath = UriPaths.normalize(this.requestURI);
             
             // Copy headers
             req.getHeaders().forEach(field -> 
@@ -2859,6 +2865,7 @@ public class ReverseConnectHandler extends Handler.Wrapper
         void setRequestURI(String requestURI)
         {
             this.requestURI = requestURI;
+            this.uriPath = UriPaths.normalize(requestURI);
             
             // Extract query string from URI
             if (requestURI != null && requestURI.contains("?"))
@@ -3018,6 +3025,15 @@ public class ReverseConnectHandler extends Handler.Wrapper
         }
 
         @Override
+        public String getUriPath()
+        {
+            if (uriPath != null) {
+                return uriPath;
+            }
+            return UriPaths.normalize(requestURI);
+        }
+
+        @Override
         public String getRequestId()
         {
             return requestId != null ? requestId : "";
@@ -3061,6 +3077,7 @@ public class ReverseConnectHandler extends Handler.Wrapper
                 copy.contentType = this.contentType;
                 copy.method = this.method;
                 copy.requestURI = this.requestURI;
+                copy.uriPath = this.uriPath;
                 copy.queryString = this.queryString;
                 copy.requestId = this.requestId;
                 copy.headers = new LinkedHashMap<>(this.headers);

--- a/logbook/src/main/java/logbook/internal/proxy/UriPaths.java
+++ b/logbook/src/main/java/logbook/internal/proxy/UriPaths.java
@@ -1,0 +1,56 @@
+package logbook.internal.proxy;
+
+import java.net.URI;
+
+/**
+ * ログ・集計用の URI パス正規化。
+ * <p>
+ * アクセスログ・API キャプチャの {@code uriPath} は本クラスの {@link #normalize(String)} に従う。
+ * API ルーティング（{@code getRequestURI()}）には使わない。
+ * </p>
+ */
+public final class UriPaths {
+
+    private UriPaths() {
+    }
+
+    /**
+     * URI からクエリ・フラグメントを除いたパス部分を返す。
+     *
+     * @param uri リクエスト URI（クエリ・絶対 URL を含む場合あり）
+     * @return パス部分（null/空入力は {@code "/"}）
+     */
+    public static String normalize(String uri) {
+        if (uri == null || uri.isEmpty()) {
+            return "/";
+        }
+
+        if (uri.startsWith("/") || !uri.contains("://")) {
+            return stripQueryAndFragment(uri);
+        }
+
+        try {
+            String path = URI.create(uri).getPath();
+            if (path == null || path.isEmpty()) {
+                return "/";
+            }
+            return path;
+        } catch (IllegalArgumentException e) {
+            return stripQueryAndFragment(uri);
+        }
+    }
+
+    private static String stripQueryAndFragment(String uri) {
+        int end = uri.length();
+        int queryIndex = uri.indexOf('?');
+        if (queryIndex >= 0) {
+            end = queryIndex;
+        }
+        int fragmentIndex = uri.indexOf('#');
+        if (fragmentIndex >= 0 && fragmentIndex < end) {
+            end = fragmentIndex;
+        }
+        String path = uri.substring(0, end);
+        return path.isEmpty() ? "/" : path;
+    }
+}

--- a/logbook/src/main/java/logbook/proxy/RequestMetaData.java
+++ b/logbook/src/main/java/logbook/proxy/RequestMetaData.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import logbook.internal.proxy.UriPaths;
+
 /**
  * リクエストに含まれている情報を ContentListener に提供するオブジェクト
  *
@@ -64,6 +66,18 @@ public interface RequestMetaData {
      * @return URI
      */
     String getRequestURI();
+
+    /**
+     * ログ・集計用のパス（クエリ・フラグメント除外）。
+     * <p>
+     * {@link #getRequestURI()} とは異なり、API ルーティングには使わない。
+     * </p>
+     *
+     * @return パス部分
+     */
+    default String getUriPath() {
+        return UriPaths.normalize(getRequestURI());
+    }
 
     /**
      * プロキシが付与したリクエスト相関ID。アクセスログとの紐づけに使用する。

--- a/logbook/src/main/java/module-info.java
+++ b/logbook/src/main/java/module-info.java
@@ -134,6 +134,7 @@ module logbook {
     opens logbook.api;
     opens logbook.bean;
     opens logbook.internal;
+    opens logbook.internal.capture;
     opens logbook.internal.metrics;
     opens logbook.internal.gui;
     opens logbook.internal.log;

--- a/logbook/src/main/resources/logbook/gui/config.fxml
+++ b/logbook/src/main/resources/logbook/gui/config.fxml
@@ -337,6 +337,22 @@
                               <Button fx:id="storeApiStart2DirRef" mnemonicParsing="false" onAction="#selectApiStart2Dir" text="参照..." GridPane.columnIndex="2" GridPane.rowIndex="10" />
                            </children>
                         </GridPane>
+                        <VBox fx:id="apiCapturePane" spacing="6.0">
+                           <padding>
+                              <Insets top="12.0" />
+                           </padding>
+                           <children>
+                              <Label text="開発者向け: すべての kcsapi レスポンスを JSONL (zstd) で保存します。requestId でアクセスログと紐づけます。" wrapText="true" />
+                              <CheckBox fx:id="apiCaptureEnabled" mnemonicParsing="false" onAction="#apiCaptureEnabledChanged" text="API レスポンスを記録する" />
+                              <HBox alignment="CENTER_LEFT" spacing="8.0">
+                                 <children>
+                                    <Label minWidth="60.0" text="保存先" />
+                                    <TextField fx:id="apiCaptureDir" HBox.hgrow="ALWAYS" maxWidth="1.7976931348623157E308" />
+                                    <Button fx:id="apiCaptureDirRef" mnemonicParsing="false" onAction="#selectApiCaptureDir" text="参照..." />
+                                 </children>
+                              </HBox>
+                           </children>
+                        </VBox>
                      </children>
                   </VBox>
                </content>

--- a/logbook/src/test/java/logbook/internal/JsonMappersTest.java
+++ b/logbook/src/test/java/logbook/internal/JsonMappersTest.java
@@ -1,16 +1,19 @@
 package logbook.internal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.InputStream;
+import java.time.Instant;
 
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import tools.jackson.core.JacksonException;
+import tools.jackson.databind.cfg.DateTimeFeature;
 
 /**
  * {@link JsonMappers} の各 Reader（MAPPER / LENIENT_READER /
@@ -178,5 +181,23 @@ class JsonMappersTest {
                 JsonMappers.STRICT_CREATOR_READER_WITH_COMMENTS
                         .forType(NameValueBean.class)
                         .readValue(jsonMissingValue));
+    }
+
+    /**
+     * API キャプチャの {@code capturedAt} 等、{@link Instant} を ISO-8601 文字列で書き出す前提。
+     * Jackson のデフォルトが数値タイムスタンプに変わった場合にここで検知する。
+     */
+    @Test
+    void mapperWritesInstantAsIso8601String() throws Exception {
+        assertFalse(JsonMappers.MAPPER.isEnabled(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS));
+
+        Instant instant = Instant.parse("2026-07-12T00:00:00Z");
+        assertEquals("\"2026-07-12T00:00:00Z\"", JsonMappers.MAPPER.writeValueAsString(instant));
+
+        record InstantHolder(Instant capturedAt) {
+        }
+        assertEquals(
+                "{\"capturedAt\":\"2026-07-12T00:00:00Z\"}",
+                JsonMappers.MAPPER.writeValueAsString(new InstantHolder(instant)));
     }
 }

--- a/logbook/src/test/java/logbook/internal/capture/ApiCaptureBodiesTest.java
+++ b/logbook/src/test/java/logbook/internal/capture/ApiCaptureBodiesTest.java
@@ -1,0 +1,114 @@
+package logbook.internal.capture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import logbook.proxy.RequestMetaData;
+import logbook.proxy.ResponseMetaData;
+
+/**
+ * {@link ApiCaptureBodies} のテスト。
+ */
+class ApiCaptureBodiesTest {
+
+    @Test
+    void readRequestBodySkipsNonPostEvenWhenBodyPresent() {
+        // body が非空でも POST 以外は null（空 Optional 由来の null と区別するため）
+        byte[] body = "api_token=abc".getBytes(StandardCharsets.UTF_8);
+        assertNull(ApiCaptureBodies.readRequestBody(stubRequest("GET", body)));
+    }
+
+    @Test
+    void readRequestBodyReturnsNullForEmptyPostBody() {
+        assertNull(ApiCaptureBodies.readRequestBody(
+                stubRequest("POST", new byte[0])));
+        assertNull(ApiCaptureBodies.readRequestBody(
+                stubRequest("POST", null)));
+    }
+
+    @Test
+    void readRequestBodyReturnsPostBody() {
+        String body = "api_token=abc&api_id=1";
+        assertEquals(body, ApiCaptureBodies.readRequestBody(
+                stubRequest("POST", body.getBytes(StandardCharsets.UTF_8))));
+    }
+
+    @Test
+    void readResponseBodyReturnsEmptyWhenMissing() {
+        assertEquals("", ApiCaptureBodies.readResponseBody(null));
+        assertEquals("", ApiCaptureBodies.readResponseBody(stubResponse(null)));
+    }
+
+    @Test
+    void readResponseBodyPreservesRawTextIncludingSvdataPrefix() {
+        String body = "svdata={\"api_result\":1}";
+        assertEquals(body, ApiCaptureBodies.readResponseBody(stubResponse(body)));
+    }
+
+    private static RequestMetaData stubRequest(String method, byte[] body) {
+        return new RequestMetaData() {
+            @Override
+            public String getContentType() {
+                return "application/x-www-form-urlencoded";
+            }
+
+            @Override
+            public String getMethod() {
+                return method;
+            }
+
+            @Override
+            public Map<String, List<String>> getParameterMap() {
+                return Map.of();
+            }
+
+            @Override
+            public String getQueryString() {
+                return "";
+            }
+
+            @Override
+            public String getRequestURI() {
+                return "/kcsapi/api_port/port";
+            }
+
+            @Override
+            public Optional<java.io.InputStream> getRequestBody() {
+                if (body == null) {
+                    return Optional.empty();
+                }
+                return Optional.of(new java.io.ByteArrayInputStream(body));
+            }
+        };
+    }
+
+    private static ResponseMetaData stubResponse(String body) {
+        byte[] bytes = body != null ? body.getBytes(StandardCharsets.UTF_8) : null;
+        return new ResponseMetaData() {
+            @Override
+            public int getStatus() {
+                return 200;
+            }
+
+            @Override
+            public String getContentType() {
+                return "text/plain";
+            }
+
+            @Override
+            public Optional<java.io.InputStream> getResponseBody() {
+                if (bytes == null) {
+                    return Optional.empty();
+                }
+                return Optional.of(new java.io.ByteArrayInputStream(bytes));
+            }
+        };
+    }
+}

--- a/logbook/src/test/java/logbook/internal/capture/ApiCaptureGateTest.java
+++ b/logbook/src/test/java/logbook/internal/capture/ApiCaptureGateTest.java
@@ -1,0 +1,113 @@
+package logbook.internal.capture;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import logbook.bean.AppConfig;
+import logbook.internal.DevMode;
+
+/**
+ * {@link ApiCaptureGate} のテスト。
+ */
+class ApiCaptureGateTest {
+
+    @BeforeEach
+    @AfterEach
+    void clearFlags() {
+        System.clearProperty(ApiCaptureGate.UI_PROPERTY);
+        System.clearProperty(ApiCaptureGate.DEV_GATE_PROPERTY);
+        System.clearProperty(ApiCaptureGate.FORCE_PROPERTY);
+        System.clearProperty(DevMode.PROPERTY);
+    }
+
+    @Test
+    void uiHiddenWithoutUiFlag() {
+        // 環境変数はテストから消せないため、未設定のときだけ検証する
+        assumeTrue(System.getenv(ApiCaptureGate.UI_ENV) == null
+                || System.getenv(ApiCaptureGate.UI_ENV).isBlank());
+        assertFalse(ApiCaptureGate.isUiAvailable());
+    }
+
+    @Test
+    void uiVisibleWithUiProperty() {
+        System.setProperty(ApiCaptureGate.UI_PROPERTY, "true");
+        assertTrue(ApiCaptureGate.isUiAvailable());
+    }
+
+    @Test
+    void uiHiddenWhenUiPropertyIsNotTrue() {
+        System.setProperty(ApiCaptureGate.UI_PROPERTY, "false");
+        assumeTrue(System.getenv(ApiCaptureGate.UI_ENV) == null
+                || System.getenv(ApiCaptureGate.UI_ENV).isBlank());
+        assertFalse(ApiCaptureGate.isUiAvailable());
+    }
+
+    @Test
+    void devGateHidesUiWithoutDevModeOrForce() {
+        System.setProperty(ApiCaptureGate.UI_PROPERTY, "true");
+        System.setProperty(ApiCaptureGate.DEV_GATE_PROPERTY, "true");
+        assertFalse(ApiCaptureGate.isUiAvailable());
+    }
+
+    @Test
+    void devGateAllowsUiWithDevMode() {
+        System.setProperty(ApiCaptureGate.UI_PROPERTY, "true");
+        System.setProperty(ApiCaptureGate.DEV_GATE_PROPERTY, "true");
+        System.setProperty(DevMode.PROPERTY, "true");
+        assertTrue(ApiCaptureGate.isUiAvailable());
+    }
+
+    @Test
+    void devGateBypassWithForce() {
+        System.setProperty(ApiCaptureGate.UI_PROPERTY, "true");
+        System.setProperty(ApiCaptureGate.DEV_GATE_PROPERTY, "true");
+        System.setProperty(ApiCaptureGate.FORCE_PROPERTY, "true");
+        assertTrue(ApiCaptureGate.isUiAvailable());
+    }
+
+    @Test
+    void captureInactiveWhenDisabled() {
+        AppConfig config = activeConfig();
+        config.setApiCaptureEnabled(false);
+        assertFalse(ApiCaptureGate.isCaptureActive(config));
+    }
+
+    @Test
+    void captureInactiveWithoutConsent() {
+        AppConfig config = activeConfig();
+        config.setApiCaptureConsentAccepted(false);
+        assertFalse(ApiCaptureGate.isCaptureActive(config));
+    }
+
+    @Test
+    void captureInactiveWhenDirBlank() {
+        AppConfig config = activeConfig();
+        config.setApiCaptureDir("  ");
+        assertFalse(ApiCaptureGate.isCaptureActive(config));
+    }
+
+    @Test
+    void captureInactiveWhenDirNull() {
+        AppConfig config = activeConfig();
+        config.setApiCaptureDir(null);
+        assertFalse(ApiCaptureGate.isCaptureActive(config));
+    }
+
+    @Test
+    void captureActiveWhenConfigured() {
+        assertTrue(ApiCaptureGate.isCaptureActive(activeConfig()));
+    }
+
+    private static AppConfig activeConfig() {
+        AppConfig config = new AppConfig();
+        config.setApiCaptureEnabled(true);
+        config.setApiCaptureConsentAccepted(true);
+        config.setApiCaptureDir("./captures");
+        return config;
+    }
+}

--- a/logbook/src/test/java/logbook/internal/capture/ApiCapturePolicyTest.java
+++ b/logbook/src/test/java/logbook/internal/capture/ApiCapturePolicyTest.java
@@ -1,0 +1,35 @@
+package logbook.internal.capture;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link ApiCapturePolicy} のテスト。
+ */
+class ApiCapturePolicyTest {
+
+    @Test
+    void capturesKcsapi() {
+        assertTrue(ApiCapturePolicy.shouldCapture("/kcsapi/api_port/port"));
+        assertTrue(ApiCapturePolicy.shouldCapture("/kcsapi/api_port/port?api_token=1"));
+    }
+
+    @Test
+    void skipsNonKcsapi() {
+        assertFalse(ApiCapturePolicy.shouldCapture("/assets/foo.png"));
+        assertFalse(ApiCapturePolicy.shouldCapture(null));
+    }
+
+    @Test
+    void registerAdditionalRule() {
+        ApiCaptureTargetRule rule = ApiCaptureTargetRule.prefix("/custom-api/");
+        ApiCapturePolicy.register(rule);
+        try {
+            assertTrue(ApiCapturePolicy.shouldCapture("/custom-api/foo"));
+        } finally {
+            // CopyOnWriteArrayList から削除 API が無いため、他テストへの影響は許容
+        }
+    }
+}

--- a/logbook/src/test/java/logbook/internal/capture/ApiCaptureSegmentStoreTest.java
+++ b/logbook/src/test/java/logbook/internal/capture/ApiCaptureSegmentStoreTest.java
@@ -1,0 +1,155 @@
+package logbook.internal.capture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * {@link ApiCaptureSegmentStore} のセグメント命名・回転のテスト。
+ */
+class ApiCaptureSegmentStoreTest {
+
+    @TempDir
+    Path tempDir;
+
+    private ApiCaptureSegmentStore store;
+
+    @AfterEach
+    void tearDown() {
+        if (this.store != null) {
+            this.store.closeQuietly();
+            this.store = null;
+        }
+    }
+
+    @Test
+    void partFileNameUsesBaseForPartOne() {
+        assertEquals("2026-07-12.jsonl.zst", ApiCaptureSegmentStore.partFileName("2026-07-12", 1));
+        assertEquals("2026-07-12.part2.jsonl.zst", ApiCaptureSegmentStore.partFileName("2026-07-12", 2));
+    }
+
+    @Test
+    void findLatestPartReturnsOneWhenMissing() throws Exception {
+        Path segments = tempDir.resolve("segments");
+        Files.createDirectories(segments);
+        assertEquals(1, ApiCaptureSegmentStore.findLatestPart(segments, "2026-07-12"));
+    }
+
+    @Test
+    void findLatestPartFollowsExistingParts() throws Exception {
+        Path segments = tempDir.resolve("segments");
+        Files.createDirectories(segments);
+        Files.writeString(segments.resolve("2026-07-12.jsonl.zst"), "x");
+        Files.writeString(segments.resolve("2026-07-12.part2.jsonl.zst"), "x");
+        Files.writeString(segments.resolve("2026-07-12.part3.jsonl.zst"), "x");
+        assertEquals(3, ApiCaptureSegmentStore.findLatestPart(segments, "2026-07-12"));
+    }
+
+    @Test
+    void appendCreatesDailySegment() throws Exception {
+        AtomicReference<LocalDate> today = new AtomicReference<>(LocalDate.of(2026, 7, 12));
+        this.store = new ApiCaptureSegmentStore(today::get);
+
+        assertTrue(this.store.append(tempDir, sample("req-1")));
+        assertTrue(this.store.isOpen());
+        assertEquals(
+                tempDir.resolve("segments").resolve("2026-07-12.jsonl.zst"),
+                this.store.currentSegmentPath());
+        assertFalse(this.store.append(tempDir, sample("req-2")));
+
+        this.store.closeQuietly();
+        assertFalse(this.store.isOpen());
+        assertTrue(Files.exists(tempDir.resolve("segments").resolve("2026-07-12.jsonl.zst")));
+    }
+
+    @Test
+    void appendRotatesOnDateChange() throws Exception {
+        AtomicReference<LocalDate> today = new AtomicReference<>(LocalDate.of(2026, 7, 12));
+        this.store = new ApiCaptureSegmentStore(today::get);
+
+        assertTrue(this.store.append(tempDir, sample("day1")));
+        this.store.closeQuietly();
+
+        today.set(LocalDate.of(2026, 7, 13));
+        assertTrue(this.store.append(tempDir, sample("day2")));
+        assertEquals(
+                tempDir.resolve("segments").resolve("2026-07-13.jsonl.zst"),
+                this.store.currentSegmentPath());
+        this.store.closeQuietly();
+
+        assertTrue(Files.exists(tempDir.resolve("segments").resolve("2026-07-12.jsonl.zst")));
+        assertTrue(Files.exists(tempDir.resolve("segments").resolve("2026-07-13.jsonl.zst")));
+    }
+
+    @Test
+    void appendRotatesOnNextWriteAfterRecordLimit() throws Exception {
+        AtomicReference<LocalDate> today = new AtomicReference<>(LocalDate.of(2026, 7, 12));
+        // 上限 2 件。2 件目まで part1、3 件目から part2
+        this.store = new ApiCaptureSegmentStore(today::get, 2);
+
+        assertTrue(this.store.append(tempDir, sample("req-a")));
+        assertFalse(this.store.append(tempDir, sample("req-b")));
+        Path first = this.store.currentSegmentPath();
+        assertEquals(tempDir.resolve("segments").resolve("2026-07-12.jsonl.zst"), first);
+
+        assertTrue(this.store.append(tempDir, sample("req-c")));
+        Path second = this.store.currentSegmentPath();
+        assertEquals(tempDir.resolve("segments").resolve("2026-07-12.part2.jsonl.zst"), second);
+        this.store.closeQuietly();
+    }
+
+    @Test
+    void partRecordCountSurvivesCloseAndReopen() throws Exception {
+        AtomicReference<LocalDate> today = new AtomicReference<>(LocalDate.of(2026, 7, 12));
+        this.store = new ApiCaptureSegmentStore(today::get, 3);
+
+        assertTrue(this.store.append(tempDir, sample("req-1")));
+        assertFalse(this.store.append(tempDir, sample("req-2")));
+        this.store.closeQuietly();
+
+        // close 後も同一 part の件数が残るため、あと 1 件で上限 → 次行で part2
+        assertTrue(this.store.append(tempDir, sample("req-3")));
+        assertEquals(
+                tempDir.resolve("segments").resolve("2026-07-12.jsonl.zst"),
+                this.store.currentSegmentPath());
+        assertTrue(this.store.append(tempDir, sample("req-4")));
+        assertEquals(
+                tempDir.resolve("segments").resolve("2026-07-12.part2.jsonl.zst"),
+                this.store.currentSegmentPath());
+        this.store.closeQuietly();
+    }
+
+    @Test
+    void resumesLatestExistingPart() throws Exception {
+        Path segments = tempDir.resolve("segments");
+        Files.createDirectories(segments);
+        Files.writeString(segments.resolve("2026-07-12.jsonl.zst"), "old");
+        Files.writeString(segments.resolve("2026-07-12.part2.jsonl.zst"), "old2");
+
+        AtomicReference<LocalDate> today = new AtomicReference<>(LocalDate.of(2026, 7, 12));
+        this.store = new ApiCaptureSegmentStore(today::get);
+        assertTrue(this.store.append(tempDir, sample("resume")));
+        assertEquals(
+                segments.resolve("2026-07-12.part2.jsonl.zst"),
+                this.store.currentSegmentPath());
+        this.store.closeQuietly();
+    }
+
+    private static ApiCaptureRecord sample(String requestId) {
+        return new ApiCaptureRecord(
+                requestId,
+                "POST",
+                "/kcsapi/api_port/port",
+                null,
+                "svdata={}");
+    }
+}

--- a/logbook/src/test/java/logbook/internal/capture/ApiCaptureWriterTest.java
+++ b/logbook/src/test/java/logbook/internal/capture/ApiCaptureWriterTest.java
@@ -1,0 +1,201 @@
+package logbook.internal.capture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.eclipse.jetty.compression.zstandard.ZstandardCompression;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+
+import logbook.internal.JsonMappers;
+
+/**
+ * {@link ApiCaptureWriteService} / {@link ApiCaptureEnvelope} /
+ * {@link ApiCaptureFlushPolicy} / {@link ApiCaptureSegmentStore} のテスト。
+ */
+class ApiCaptureWriterTest {
+
+    @TempDir
+    Path tempDir;
+
+    private ApiCaptureWriteService service;
+
+    @AfterEach
+    void tearDown() {
+        if (this.service != null) {
+            this.service.shutdown();
+            this.service = null;
+        }
+    }
+
+    @Test
+    void rejectsEnqueueAfterShutdown() {
+        this.service = newService(tempDir, () -> true);
+        this.service.shutdown();
+        assertFalse(this.service.enqueue(sampleRecord("req-late")));
+    }
+
+    @Test
+    void shutdownIsIdempotent() {
+        this.service = newService(tempDir, () -> true);
+        this.service.shutdown();
+        this.service.shutdown();
+        assertFalse(this.service.enqueue(sampleRecord("req-after-double-shutdown")));
+    }
+
+    @Test
+    void flushKeepsAccepting() {
+        this.service = newService(tempDir, () -> true);
+        assertTrue(this.service.enqueue(sampleRecord("req-before-flush")));
+        this.service.flush();
+        assertTrue(this.service.enqueue(sampleRecord("req-after-flush")));
+        this.service.flush();
+    }
+
+    @Test
+    void writesJsonlZstSegment() throws Exception {
+        Path captureDir = tempDir.resolve("captures");
+        this.service = newService(captureDir, () -> true);
+
+        String responseBody = "svdata={\"api_result\":1,\"api_data\":{\"foo\":\"bar\"}}";
+        ApiCaptureRecord record = new ApiCaptureRecord(
+                "req-123",
+                "POST",
+                "/kcsapi/api_port/port",
+                "api_token=abc",
+                responseBody);
+
+        assertTrue(this.service.enqueue(record));
+        this.service.flush();
+
+        JsonObject envelope = readFirstEnvelope(findSegment(captureDir));
+        assertEquals(1, envelope.getInt("v"));
+        assertEquals("req-123", envelope.getString("requestId"));
+        assertEquals("POST", envelope.getString("method"));
+        assertEquals("/kcsapi/api_port/port", envelope.getString("uriPath"));
+        assertFalse(envelope.containsKey("uri"));
+        assertEquals("api_token=abc", envelope.getString("request"));
+        assertEquals(responseBody, envelope.getString("response"));
+        assertTrue(envelope.containsKey("capturedAt"));
+    }
+
+    @Test
+    void omitsRequestFieldWhenRequestBodyIsNull() throws Exception {
+        Path captureDir = tempDir.resolve("captures");
+        this.service = newService(captureDir, () -> true);
+
+        assertTrue(this.service.enqueue(new ApiCaptureRecord(
+                "req-no-body",
+                "POST",
+                "/kcsapi/api_port/port",
+                null,
+                "svdata={}")));
+        this.service.flush();
+
+        JsonObject envelope = readFirstEnvelope(findSegment(captureDir));
+        assertFalse(envelope.containsKey("request"));
+        assertEquals("svdata={}", envelope.getString("response"));
+    }
+
+    @Test
+    void discardsWhenCaptureInactive() throws Exception {
+        Path captureDir = tempDir.resolve("captures");
+        this.service = newService(captureDir, () -> false);
+
+        assertTrue(this.service.enqueue(sampleRecord("req-inactive")));
+        this.service.flush();
+
+        assertFalse(Files.exists(captureDir.resolve("segments")));
+    }
+
+    @Test
+    void envelopeOmitsNullRequest() {
+        ApiCaptureEnvelope envelope = ApiCaptureEnvelope.from(
+                new ApiCaptureRecord("id", "POST", "/kcsapi/x", null, "svdata={}"),
+                Instant.parse("2026-07-12T00:00:00Z"));
+        String json = JsonMappers.MAPPER.writeValueAsString(envelope);
+        assertFalse(json.contains("\"request\""));
+        assertTrue(json.contains("\"response\":\"svdata={}\""));
+        assertTrue(json.contains("\"capturedAt\":\"2026-07-12T00:00:00Z\""));
+    }
+
+    @Test
+    void flushPolicyTriggersByRecordCount() {
+        ApiCaptureFlushPolicy policy = new ApiCaptureFlushPolicy(2, 60_000L, 5, 60_000L);
+        long t0 = 0L;
+        assertFalse(policy.shouldFlushEncoder(1, t0, t0));
+        assertTrue(policy.shouldFlushEncoder(2, t0, t0));
+        assertFalse(policy.shouldCloseSegment(4, t0, t0));
+        assertTrue(policy.shouldCloseSegment(5, t0, t0));
+    }
+
+    @Test
+    void flushPolicyTriggersByElapsedTime() {
+        ApiCaptureFlushPolicy policy = new ApiCaptureFlushPolicy(100, 1_000L, 100, 2_000L);
+        long t0 = 0L;
+        long after1s = 1_000_000_000L;
+        long after2s = 2_000_000_000L;
+        assertTrue(policy.shouldFlushEncoderByTime(t0, after1s));
+        assertFalse(policy.shouldCloseSegmentByTime(t0, after1s));
+        assertTrue(policy.shouldCloseSegmentByTime(t0, after2s));
+    }
+
+    private ApiCaptureWriteService newService(Path captureDir, java.util.function.Supplier<Boolean> active) {
+        return new ApiCaptureWriteService(
+                active,
+                () -> captureDir,
+                ApiCaptureFlushPolicy.DEFAULT,
+                new AtomicLong()::get);
+    }
+
+    private static ApiCaptureRecord sampleRecord(String requestId) {
+        return new ApiCaptureRecord(
+                requestId,
+                "POST",
+                "/kcsapi/api_port/port",
+                null,
+                "svdata={}");
+    }
+
+    private static Path findSegment(Path captureDir) throws Exception {
+        Path segmentsDir = captureDir.resolve("segments");
+        assertTrue(Files.isDirectory(segmentsDir));
+        try (var files = Files.list(segmentsDir)) {
+            return files.filter(p -> p.getFileName().toString().endsWith(".jsonl.zst"))
+                    .findFirst()
+                    .orElseThrow();
+        }
+    }
+
+    private static JsonObject readFirstEnvelope(Path zstFile) throws Exception {
+        ZstandardCompression zstandard = new ZstandardCompression();
+        zstandard.start();
+        byte[] compressed = Files.readAllBytes(zstFile);
+        ByteArrayOutputStream plain = new ByteArrayOutputStream();
+        try (InputStream in = new ByteArrayInputStream(compressed);
+                InputStream decoded = zstandard.newDecoderInputStream(in, zstandard.getDefaultDecoderConfig())) {
+            decoded.transferTo(plain);
+        }
+        String text = plain.toString(StandardCharsets.UTF_8);
+        String firstLine = text.substring(0, text.indexOf('\n'));
+        try (JsonReader reader = Json.createReader(new StringReader(firstLine))) {
+            return reader.readObject();
+        }
+    }
+}

--- a/logbook/src/test/java/logbook/internal/proxy/UriPathsTest.java
+++ b/logbook/src/test/java/logbook/internal/proxy/UriPathsTest.java
@@ -1,0 +1,34 @@
+package logbook.internal.proxy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link UriPaths} のテスト。
+ */
+class UriPathsTest {
+
+    @Test
+    void normalizeNullOrEmpty() {
+        assertEquals("/", UriPaths.normalize(null));
+        assertEquals("/", UriPaths.normalize(""));
+    }
+
+    @Test
+    void normalizeStripsQueryAndFragment() {
+        assertEquals("/kcsapi/api_port/port", UriPaths.normalize("/kcsapi/api_port/port?x=1"));
+        assertEquals("/kcsapi/api_port/port", UriPaths.normalize("/kcsapi/api_port/port#anchor"));
+        assertEquals("/kcsapi/foo", UriPaths.normalize("/kcsapi/foo?a=1#b"));
+    }
+
+    @Test
+    void normalizeAbsoluteUrl() {
+        assertEquals("/kcsapi/api_port/port", UriPaths.normalize("https://host/kcsapi/api_port/port?q=1"));
+    }
+
+    @Test
+    void normalizePathOnly() {
+        assertEquals("/kcsapi/api_port/port", UriPaths.normalize("/kcsapi/api_port/port"));
+    }
+}


### PR DESCRIPTION
#### 変更内容
API レスポンスキャプチャ機能の追加
開発・分析用に kcsapi のリクエスト／レスポンス原文をJSONL形式+zstdで保存出来るように変更
一般ユーザー向けで無いので、UIはフラグを設定した場合のみ表示

#### 関連するIssue
Fixes #226

