### PR TITLE
APIキャプチャのバイナリ対応と対象をプロパティに切り出し対応

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -6,6 +6,7 @@
 |------|------|
 | [jmx_exporter/jmx-exporter-config.yaml](jmx_exporter/jmx-exporter-config.yaml) | Prometheus JMX Exporter 設定 |
 | [logback/logback.xml](logback/logback.xml) | アクセスログ出力用 logback 設定サンプル |
+| [api-capture-rules.properties](api-capture-rules.properties) | API キャプチャ対象（`mvn -Pdev` で同梱。配布は空） |
 
 ---
 
@@ -242,7 +243,15 @@ JSON 形式は `ContentListenerLogJson` appender を参照してください（`
 ## API レスポンス記録（開発者向け）
 
 kcsapi のレスポンス JSON を `{captureDir}/segments/{日付}.jsonl.zst` に JSONL + zstd で保存します。
-`ReverseConnectHandler.invoke()` 入口の `ApiCaptureHook` が対象 URI のボディ原文を 1 回記録します（既定: すべての `/kcsapi/`）。
+`ReverseConnectHandler.invoke()` 入口の `ApiCaptureHook` が対象 URI のボディ原文を 1 回記録します。
+対象 URI はプロパティ `logbook/capture/api-capture-rules.properties` で定義します。
+
+| ビルド | ルール |
+|--------|--------|
+| 配布（通常の `mvn package`） | **空**（記録を ON にしてもキャプチャされない） |
+| 開発（`mvn -Pdev package`） | [`dev/api-capture-rules.properties`](api-capture-rules.properties) を同梱（現行: `/kcsapi/`・`/kcs2/js/`・`/kcs2/version.json`・`/kcs2/resources/map/`） |
+
+`--dev` / `-Dlogbook.dev=true` ではルールは切り替わりません（ビルド成果物の同梱内容が正）。
 POST リクエストは `request` フィールドにボディ原文、レスポンスは `response` フィールドに解凍後原文として同梱します。
 **別途インデックスファイルは持たず**、各レコードの `requestId` でアクセスログと紐づけます。
 
@@ -270,15 +279,27 @@ POST リクエストは `request` フィールドにボディ原文、レスポ�
 3. 保存先を指定して OK
 4. 記録中はメインウィンドウタイトルに `[API記録中]` が付きます
 
-### 対象 URI の拡張（開発者向け）
+### 対象 URI の変更（開発者向け）
 
-既定は `/kcsapi/` のみ。別パスを追加する場合:
+ルールは Java ではなくプロパティで管理します。
 
-```java
-ApiCapturePolicy.register(ApiCaptureTargetRule.prefix("/custom-api/"));
+1. [`dev/api-capture-rules.properties`](api-capture-rules.properties) を編集
+2. `mvn -Pdev package` で再ビルド
+
+形式:
+
+```properties
+prefix.1=/kcsapi/
+prefix.2=/kcs2/js/
+prefix.3=/kcs2/version.json
+prefix.4=/kcs2/resources/map/
 ```
 
-ボディは原文のまま保存されます。分析時に必要なパースは `read_segments.py` 等で行います。
+プロセス内の一時追加のみ `ApiCapturePolicy.register(...)` を使えます（上書きではなく末尾追加）。
+
+ボディはテキストを UTF-8 原文、バイナリを Base64 で可逆保存します（スキーマ v3。詳細は document の `docs/api-capture/format.md`）。
+**304 Not Modified は記録しません**（ボディなし。アクセスログで確認）。
+分析時に必要なパースは `read_segments.py` 等で行います。map 資産のファイル復元は document の `tools/client-assets/extract_map_assets.py`。
 
 ### ログとの突合
 

--- a/dev/api-capture-rules.properties
+++ b/dev/api-capture-rules.properties
@@ -1,0 +1,14 @@
+# API キャプチャ対象 URI（開発ビルド）
+#
+# mvn -Pdev package で JAR に同梱される。
+#
+# 形式: prefix.<n>=<path>（n 昇順。欠番可）
+#
+# /kcs2/ 全体・/kcs2/img/・/kcs2/index.php・/kcs2/resources/ 全体は対象外
+# （hc.html 高頻度、ImageListener、api_token、艦娘画像の常時取得）
+# 例外: /kcs2/resources/map/ のみ調査用にキャプチャする（フェーズ1）
+
+prefix.1=/kcsapi/
+prefix.2=/kcs2/js/
+prefix.3=/kcs2/version.json
+prefix.4=/kcs2/resources/map/

--- a/how-to-build.md
+++ b/how-to-build.md
@@ -17,9 +17,13 @@ MANIFEST.MF には次の情報が記録されます。
 
 ## ビルドオプション（プロファイル）
 
-### -Pdev（開発用テスト）
+### -Pdev（開発用テスト / 開発用プロパティ同梱）
 
-`-Pdev` を付けてビルドすると、Maven Surefire にシステムプロパティ `test.profile=dev` が渡され、**一部のテストだけが有効化**されます。通常の `mvn package` ではこれらのテストはスキップされます。
+`-Pdev` を付けてビルドすると、次が行われます。
+
+1. Maven Surefire にシステムプロパティ `test.profile=dev` が渡され、**一部のテストだけが有効化**される
+2. 次の開発用プロパティが JAR に同梱される（通常ビルドは配布用）
+   - [`dev/api-capture-rules.properties`](dev/api-capture-rules.properties)（API キャプチャ対象。配布は空）
 
 ```
 mvn -Pdev package

--- a/logbook/pom.xml
+++ b/logbook/pom.xml
@@ -290,6 +290,36 @@
             <properties>
                 <test.profile>dev</test.profile>
             </properties>
+            <build>
+                <plugins>
+                    <!-- 配布用プロパティを開発用（dev/*.properties）で上書きしてから JAR 化 -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>api-capture-rules-dev</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.outputDirectory}/logbook/capture</outputDirectory>
+                                    <overwrite>true</overwrite>
+                                    <resources>
+                                        <resource>
+                                            <directory>${project.basedir}/../dev</directory>
+                                            <includes>
+                                                <include>api-capture-rules.properties</include>
+                                            </includes>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>extract-sources</id>

--- a/logbook/src/main/java/logbook/internal/capture/ApiCaptureBodies.java
+++ b/logbook/src/main/java/logbook/internal/capture/ApiCaptureBodies.java
@@ -2,23 +2,53 @@ package logbook.internal.capture;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Locale;
 
 import logbook.proxy.RequestMetaData;
 import logbook.proxy.ResponseMetaData;
 
 /**
- * キャプチャ用に HTTP ボディ原文を読み取る。
+ * キャプチャ用に HTTP ボディを読み取り、JSONL 用の文字列とエンコーディングを決める。
+ * <p>
+ * テキストは {@code utf8}（原文）、バイナリは {@code base64} で可逆保存する。
+ * </p>
  */
 final class ApiCaptureBodies {
+
+    static final String ENCODING_UTF8 = "utf8";
+    static final String ENCODING_BASE64 = "base64";
+
+    /**
+     * エンベロープへ載せるボディ。{@code content} は encoding に応じた文字列。
+     */
+    record CapturedBody(String encoding, String content) {
+
+        static CapturedBody utf8(String content) {
+            return new CapturedBody(ENCODING_UTF8, content != null ? content : "");
+        }
+
+        static CapturedBody base64(byte[] bytes) {
+            return new CapturedBody(ENCODING_BASE64, Base64.getEncoder().encodeToString(bytes));
+        }
+
+        static CapturedBody emptyUtf8() {
+            return utf8("");
+        }
+    }
 
     private ApiCaptureBodies() {
     }
 
     /**
-     * POST リクエストボディ原文。POST 以外または空の場合は {@code null}。
+     * POST リクエストボディ。POST 以外または空の場合は {@code null}。
      */
-    static String readRequestBody(RequestMetaData req) {
+    static CapturedBody readRequestBody(RequestMetaData req) {
         if (req == null) {
             return null;
         }
@@ -27,28 +57,122 @@ final class ApiCaptureBodies {
             return null;
         }
         return req.getRequestBody()
-                .map(ApiCaptureBodies::readStream)
-                .filter(body -> !body.isEmpty())
+                .map(stream -> encode(readBytes(stream), req.getContentType()))
+                .filter(body -> !body.content().isEmpty())
                 .orElse(null);
     }
 
     /**
-     * レスポンスボディ原文。取得できない場合は空文字。
+     * レスポンスボディ。取得できない場合は空の utf8。
      */
-    static String readResponseBody(ResponseMetaData res) {
+    static CapturedBody readResponseBody(ResponseMetaData res) {
         if (res == null) {
-            return "";
+            return CapturedBody.emptyUtf8();
         }
         return res.getResponseBody()
-                .map(ApiCaptureBodies::readStream)
-                .orElse("");
+                .map(stream -> encode(readBytes(stream), res.getContentType()))
+                .orElse(CapturedBody.emptyUtf8());
     }
 
-    private static String readStream(InputStream stream) {
+    /**
+     * Content-Type とバイト列からエンコーディングを決めて文字列化する。
+     * テストからも利用する。
+     */
+    static CapturedBody encode(byte[] bytes, String contentType) {
+        if (bytes == null || bytes.length == 0) {
+            return CapturedBody.emptyUtf8();
+        }
+        if (isTextual(contentType, bytes)) {
+            return CapturedBody.utf8(new String(bytes, StandardCharsets.UTF_8));
+        }
+        return CapturedBody.base64(bytes);
+    }
+
+    static boolean isTextual(String contentType, byte[] bytes) {
+        String media = mediaType(contentType);
+        if (media != null) {
+            if (isTextualMediaType(media)) {
+                return true;
+            }
+            if (isBinaryMediaType(media)) {
+                return false;
+            }
+        }
+        return looksLikeUtf8Text(bytes);
+    }
+
+    private static String mediaType(String contentType) {
+        if (contentType == null || contentType.isBlank()) {
+            return null;
+        }
+        String media = contentType;
+        int semi = media.indexOf(';');
+        if (semi >= 0) {
+            media = media.substring(0, semi);
+        }
+        media = media.trim().toLowerCase(Locale.ROOT);
+        return media.isEmpty() ? null : media;
+    }
+
+    private static boolean isTextualMediaType(String media) {
+        if (media.startsWith("text/")) {
+            return true;
+        }
+        return switch (media) {
+            case "application/json",
+                    "application/javascript",
+                    "application/ecmascript",
+                    "application/xml",
+                    "application/xhtml+xml",
+                    "application/x-www-form-urlencoded",
+                    "application/ld+json" -> true;
+            default -> media.endsWith("+json")
+                    || media.endsWith("+xml")
+                    || media.contains("javascript")
+                    || media.contains("ecmascript");
+        };
+    }
+
+    private static boolean isBinaryMediaType(String media) {
+        if (media.startsWith("image/")
+                || media.startsWith("audio/")
+                || media.startsWith("video/")
+                || media.startsWith("font/")) {
+            return true;
+        }
+        return switch (media) {
+            case "application/octet-stream",
+                    "application/zip",
+                    "application/gzip",
+                    "application/pdf",
+                    "application/wasm",
+                    "application/x-protobuf" -> true;
+            default -> false;
+        };
+    }
+
+    private static boolean looksLikeUtf8Text(byte[] bytes) {
+        for (byte b : bytes) {
+            if (b == 0) {
+                return false;
+            }
+        }
+        CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT);
+        try {
+            decoder.decode(ByteBuffer.wrap(bytes));
+            return true;
+        } catch (CharacterCodingException e) {
+            return false;
+        }
+    }
+
+    private static byte[] readBytes(InputStream stream) {
         try (stream) {
-            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+            return stream.readAllBytes();
         } catch (IOException e) {
-            return "";
+            return new byte[0];
         }
     }
 }

--- a/logbook/src/main/java/logbook/internal/capture/ApiCaptureEnvelope.java
+++ b/logbook/src/main/java/logbook/internal/capture/ApiCaptureEnvelope.java
@@ -21,21 +21,44 @@ public record ApiCaptureEnvelope(
         Instant capturedAt,
         String method,
         String uriPath,
+        String uri,
+        String contentType,
+        String requestEncoding,
         @JsonProperty("request") String request,
+        String responseEncoding,
         @JsonProperty("response") String response) {
 
     static ApiCaptureEnvelope from(ApiCaptureRecord record, Instant capturedAt) {
+        String requestBody = record.requestBody();
         return new ApiCaptureEnvelope(
-                1,
+                3,
                 nullToEmpty(record.requestId()),
                 capturedAt,
                 nullToEmpty(record.method()),
                 nullToEmpty(record.uriPath()),
-                record.requestBody(),
+                nullToEmpty(record.uri()),
+                blankToNull(record.contentType()),
+                requestBody == null ? null : defaultEncoding(record.requestEncoding()),
+                requestBody,
+                defaultEncoding(record.responseEncoding()),
                 nullToEmpty(record.responseBody()));
     }
 
     private static String nullToEmpty(String value) {
         return value != null ? value : "";
+    }
+
+    private static String blankToNull(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value;
+    }
+
+    private static String defaultEncoding(String encoding) {
+        if (encoding == null || encoding.isBlank()) {
+            return ApiCaptureBodies.ENCODING_UTF8;
+        }
+        return encoding;
     }
 }

--- a/logbook/src/main/java/logbook/internal/capture/ApiCaptureHook.java
+++ b/logbook/src/main/java/logbook/internal/capture/ApiCaptureHook.java
@@ -1,5 +1,8 @@
 package logbook.internal.capture;
 
+import java.net.HttpURLConnection;
+
+import lombok.extern.slf4j.Slf4j;
 import logbook.proxy.RequestMetaData;
 import logbook.proxy.ResponseMetaData;
 
@@ -9,13 +12,17 @@ import logbook.proxy.ResponseMetaData;
  * 記録可否（{@link ApiCaptureGate}）と URI 対象（{@link ApiCapturePolicy}）の判定はここだけで行う。
  * </p>
  */
+@Slf4j
 public final class ApiCaptureHook {
 
     private ApiCaptureHook() {
     }
 
     /**
-     * 記録が有効かつ対象 URI の場合、ボディ原文をキューへ追加する。
+     * 記録が有効かつ対象 URI の場合、ボディをキューへ追加する。
+     * <p>
+     * {@code 304 Not Modified} はボディを持たないため記録しない（アクセスログの {@code requestId} で突合可能）。
+     * </p>
      */
     public static void captureIfNeeded(RequestMetaData request, ResponseMetaData response) {
         if (!ApiCaptureGate.isCaptureActive()) {
@@ -25,14 +32,36 @@ public final class ApiCaptureHook {
         if (!ApiCapturePolicy.shouldCapture(uri)) {
             return;
         }
-        String requestBody = ApiCaptureBodies.readRequestBody(request);
-        String responseBody = ApiCaptureBodies.readResponseBody(response);
+        if (!shouldCaptureResponse(response)) {
+            log.debug("APIキャプチャをスキップ（304 Not Modified）: uriPath={}", request.getUriPath());
+            return;
+        }
+        ApiCaptureBodies.CapturedBody requestBody = ApiCaptureBodies.readRequestBody(request);
+        ApiCaptureBodies.CapturedBody responseBody = ApiCaptureBodies.readResponseBody(response);
         ApiCaptureRecord record = new ApiCaptureRecord(
                 request.getRequestId(),
                 request.getMethod(),
                 request.getUriPath(),
-                requestBody,
-                responseBody);
+                uri,
+                blankToNull(response != null ? response.getContentType() : null),
+                requestBody != null ? requestBody.content() : null,
+                requestBody != null ? requestBody.encoding() : null,
+                responseBody.content(),
+                responseBody.encoding());
         ApiCaptureWriter.enqueue(record);
+    }
+
+    /**
+     * レスポンスをキャプチャ対象とするか。{@code 304} はボディを持たないため除外する。
+     */
+    static boolean shouldCaptureResponse(ResponseMetaData response) {
+        return response == null || response.getStatus() != HttpURLConnection.HTTP_NOT_MODIFIED;
+    }
+
+    private static String blankToNull(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value;
     }
 }

--- a/logbook/src/main/java/logbook/internal/capture/ApiCapturePolicy.java
+++ b/logbook/src/main/java/logbook/internal/capture/ApiCapturePolicy.java
@@ -3,18 +3,21 @@ package logbook.internal.capture;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * API キャプチャ対象 URI の判定。
  * <p>
- * 既定では {@code /kcsapi/} を対象とする。
- * {@link #register(ApiCaptureTargetRule)} でルールを追加できる。
+ * ルール本文はプロパティ（{@link ApiCaptureRulesLoader}）から読む。
+ * 配布ビルドは空ルールのため、記録を ON にしてもキャプチャされない。
+ * 開発ビルドは {@code mvn -Pdev} で {@code dev/api-capture-rules.properties} を同梱する。
+ * {@link #register(ApiCaptureTargetRule)} でプロセス内にルールを追加できる。
  * </p>
  */
 public final class ApiCapturePolicy {
 
-    private static final List<ApiCaptureTargetRule> RULES = new CopyOnWriteArrayList<>(
-            List.of(ApiCaptureTargetRule.prefix("/kcsapi/")));
+    private static final List<ApiCaptureTargetRule> RULES = new CopyOnWriteArrayList<>();
+    private static final AtomicBoolean LOADED = new AtomicBoolean(false);
 
     private ApiCapturePolicy() {
     }
@@ -23,6 +26,7 @@ public final class ApiCapturePolicy {
      * キャプチャ対象ルールを末尾に追加する。
      */
     public static void register(ApiCaptureTargetRule rule) {
+        ensureLoaded();
         RULES.add(Objects.requireNonNull(rule));
     }
 
@@ -35,11 +39,27 @@ public final class ApiCapturePolicy {
         if (uri == null) {
             return false;
         }
+        ensureLoaded();
         for (ApiCaptureTargetRule rule : RULES) {
             if (rule.matches(uri)) {
                 return true;
             }
         }
         return false;
+    }
+
+    private static void ensureLoaded() {
+        if (LOADED.compareAndSet(false, true)) {
+            RULES.addAll(ApiCaptureRulesLoader.load());
+        }
+    }
+
+    /**
+     * テスト用にルールを差し替える。
+     */
+    static void replaceRulesForTest(List<ApiCaptureTargetRule> rules) {
+        RULES.clear();
+        RULES.addAll(Objects.requireNonNull(rules));
+        LOADED.set(true);
     }
 }

--- a/logbook/src/main/java/logbook/internal/capture/ApiCaptureRecord.java
+++ b/logbook/src/main/java/logbook/internal/capture/ApiCaptureRecord.java
@@ -6,13 +6,21 @@ package logbook.internal.capture;
  * @param requestId アクセスログと同一の相関 ID
  * @param method HTTP メソッド
  * @param uriPath パスのみ（{@link logbook.internal.proxy.UriPaths#normalize} と同一規則）
- * @param requestBody POST ボディ原文（POST 以外または空の場合は null）
- * @param responseBody レスポンスボディ原文
+ * @param uri クエリを含むリクエスト URI
+ * @param contentType レスポンス Content-Type（無い場合は null）
+ * @param requestBody POST ボディ（エンコーディング済み文字列。POST 以外または空は null）
+ * @param requestEncoding {@code utf8} / {@code base64}（requestBody が null のとき null）
+ * @param responseBody レスポンスボディ（エンコーディング済み文字列）
+ * @param responseEncoding {@code utf8} / {@code base64}
  */
 public record ApiCaptureRecord(
         String requestId,
         String method,
         String uriPath,
+        String uri,
+        String contentType,
         String requestBody,
-        String responseBody) {
+        String requestEncoding,
+        String responseBody,
+        String responseEncoding) {
 }

--- a/logbook/src/main/java/logbook/internal/capture/ApiCaptureRulesLoader.java
+++ b/logbook/src/main/java/logbook/internal/capture/ApiCaptureRulesLoader.java
@@ -1,0 +1,97 @@
+package logbook.internal.capture;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * API キャプチャ対象ルールをプロパティから読み取る。
+ * <p>
+ * classpath の {@link #CLASSPATH_RESOURCE} のみを読む。
+ * 配布ビルドは空ルール、開発ビルド（{@code -Pdev}）は
+ * {@code dev/api-capture-rules.properties} を同梱する。
+ * </p>
+ */
+@Slf4j
+final class ApiCaptureRulesLoader {
+
+    /** 配布 / 開発ビルドが同梱する classpath 上のリソース */
+    static final String CLASSPATH_RESOURCE = "/logbook/capture/api-capture-rules.properties";
+
+    private static final Pattern PREFIX_KEY = Pattern.compile("^prefix\\.(\\d+)$");
+
+    private ApiCaptureRulesLoader() {
+    }
+
+    /**
+     * classpath からルール一覧を返す（空でもよい）。
+     */
+    static List<ApiCaptureTargetRule> load() {
+        try (InputStream in = ApiCaptureRulesLoader.class.getResourceAsStream(CLASSPATH_RESOURCE)) {
+            if (in == null) {
+                log.warn("APIキャプチャルールが classpath にありません: {}", CLASSPATH_RESOURCE);
+                return List.of();
+            }
+            List<ApiCaptureTargetRule> rules = parse(in);
+            if (rules.isEmpty()) {
+                log.debug("APIキャプチャルールは空です（配布ビルドまたは未設定）");
+            } else {
+                log.info("APIキャプチャルールを classpath から読み込みました: rules={}", rules.size());
+            }
+            return rules;
+        } catch (IOException e) {
+            log.warn("APIキャプチャルールの読み込みに失敗しました", e);
+            return List.of();
+        }
+    }
+
+    /**
+     * プロパティから {@code prefix.<n>} を昇順で読み、ルール一覧にする。
+     */
+    static List<ApiCaptureTargetRule> parse(InputStream in) throws IOException {
+        Properties properties = new Properties();
+        try (Reader reader = new InputStreamReader(in, StandardCharsets.UTF_8)) {
+            properties.load(reader);
+        }
+        return parse(properties);
+    }
+
+    static List<ApiCaptureTargetRule> parse(Properties properties) {
+        List<Map.Entry<Integer, String>> entries = new ArrayList<>();
+        for (String name : properties.stringPropertyNames()) {
+            Matcher matcher = PREFIX_KEY.matcher(name);
+            if (matcher.matches()) {
+                String value = properties.getProperty(name);
+                if (value == null || value.isBlank()) {
+                    log.warn("APIキャプチャルールが空です: {}", name);
+                    continue;
+                }
+                entries.add(Map.entry(Integer.parseInt(matcher.group(1)), value.trim()));
+                continue;
+            }
+            log.warn("未知のAPIキャプチャルールキーを無視します: {}", name);
+        }
+        entries.sort(Comparator.comparingInt(Map.Entry::getKey));
+        List<ApiCaptureTargetRule> rules = new ArrayList<>(entries.size());
+        for (Map.Entry<Integer, String> entry : entries) {
+            try {
+                rules.add(ApiCaptureTargetRule.prefix(entry.getValue()));
+            } catch (IllegalArgumentException e) {
+                log.warn("不正なAPIキャプチャ prefix を無視します: prefix.{}={}",
+                        entry.getKey(), entry.getValue(), e);
+            }
+        }
+        return List.copyOf(rules);
+    }
+}

--- a/logbook/src/main/resources/logbook/capture/api-capture-rules.properties
+++ b/logbook/src/main/resources/logbook/capture/api-capture-rules.properties
@@ -1,0 +1,7 @@
+# API キャプチャ対象 URI（配布ビルド）
+#
+# 配布用はルールを空にする。設定 UI / フラグを ON にしてもキャプチャされない。
+# 開発用ルールはリポジトリの dev/api-capture-rules.properties。
+# 開発ビルド: mvn -Pdev package
+#
+# 形式: prefix.<n>=<path>（n 昇順。欠番可）

--- a/logbook/src/test/java/logbook/internal/capture/ApiCaptureBodiesTest.java
+++ b/logbook/src/test/java/logbook/internal/capture/ApiCaptureBodiesTest.java
@@ -1,9 +1,11 @@
 package logbook.internal.capture;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -22,41 +24,83 @@ class ApiCaptureBodiesTest {
     void readRequestBodySkipsNonPostEvenWhenBodyPresent() {
         // body が非空でも POST 以外は null（空 Optional 由来の null と区別するため）
         byte[] body = "api_token=abc".getBytes(StandardCharsets.UTF_8);
-        assertNull(ApiCaptureBodies.readRequestBody(stubRequest("GET", body)));
+        assertNull(ApiCaptureBodies.readRequestBody(stubRequest("GET", body, "application/x-www-form-urlencoded")));
     }
 
     @Test
     void readRequestBodyReturnsNullForEmptyPostBody() {
         assertNull(ApiCaptureBodies.readRequestBody(
-                stubRequest("POST", new byte[0])));
+                stubRequest("POST", new byte[0], "application/x-www-form-urlencoded")));
         assertNull(ApiCaptureBodies.readRequestBody(
-                stubRequest("POST", null)));
+                stubRequest("POST", null, "application/x-www-form-urlencoded")));
     }
 
     @Test
-    void readRequestBodyReturnsPostBody() {
+    void readRequestBodyReturnsPostBodyAsUtf8() {
         String body = "api_token=abc&api_id=1";
-        assertEquals(body, ApiCaptureBodies.readRequestBody(
-                stubRequest("POST", body.getBytes(StandardCharsets.UTF_8))));
+        ApiCaptureBodies.CapturedBody captured = ApiCaptureBodies.readRequestBody(
+                stubRequest("POST", body.getBytes(StandardCharsets.UTF_8), "application/x-www-form-urlencoded"));
+        assertEquals(ApiCaptureBodies.ENCODING_UTF8, captured.encoding());
+        assertEquals(body, captured.content());
     }
 
     @Test
     void readResponseBodyReturnsEmptyWhenMissing() {
-        assertEquals("", ApiCaptureBodies.readResponseBody(null));
-        assertEquals("", ApiCaptureBodies.readResponseBody(stubResponse(null)));
+        assertEquals("", ApiCaptureBodies.readResponseBody(null).content());
+        assertEquals(ApiCaptureBodies.ENCODING_UTF8, ApiCaptureBodies.readResponseBody(null).encoding());
+        assertEquals("", ApiCaptureBodies.readResponseBody(stubResponse(null, "text/plain")).content());
     }
 
     @Test
     void readResponseBodyPreservesRawTextIncludingSvdataPrefix() {
         String body = "svdata={\"api_result\":1}";
-        assertEquals(body, ApiCaptureBodies.readResponseBody(stubResponse(body)));
+        ApiCaptureBodies.CapturedBody captured = ApiCaptureBodies.readResponseBody(
+                stubResponse(body.getBytes(StandardCharsets.UTF_8), "text/plain"));
+        assertEquals(ApiCaptureBodies.ENCODING_UTF8, captured.encoding());
+        assertEquals(body, captured.content());
     }
 
-    private static RequestMetaData stubRequest(String method, byte[] body) {
+    @Test
+    void encodeUsesBase64ForImagePng() {
+        byte[] png = new byte[] {
+                (byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D
+        };
+        ApiCaptureBodies.CapturedBody captured = ApiCaptureBodies.encode(png, "image/png");
+        assertEquals(ApiCaptureBodies.ENCODING_BASE64, captured.encoding());
+        assertArrayEquals(png, Base64.getDecoder().decode(captured.content()));
+    }
+
+    @Test
+    void encodeUsesUtf8ForApplicationJson() {
+        byte[] json = "{\"a\":1}".getBytes(StandardCharsets.UTF_8);
+        ApiCaptureBodies.CapturedBody captured = ApiCaptureBodies.encode(json, "application/json; charset=UTF-8");
+        assertEquals(ApiCaptureBodies.ENCODING_UTF8, captured.encoding());
+        assertEquals("{\"a\":1}", captured.content());
+    }
+
+    @Test
+    void encodeSniffsBinaryWhenContentTypeMissing() {
+        byte[] png = new byte[] {
+                (byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A
+        };
+        ApiCaptureBodies.CapturedBody captured = ApiCaptureBodies.encode(png, null);
+        assertEquals(ApiCaptureBodies.ENCODING_BASE64, captured.encoding());
+        assertArrayEquals(png, Base64.getDecoder().decode(captured.content()));
+    }
+
+    @Test
+    void encodeSniffsUtf8WhenContentTypeMissing() {
+        byte[] text = "hello".getBytes(StandardCharsets.UTF_8);
+        ApiCaptureBodies.CapturedBody captured = ApiCaptureBodies.encode(text, null);
+        assertEquals(ApiCaptureBodies.ENCODING_UTF8, captured.encoding());
+        assertEquals("hello", captured.content());
+    }
+
+    private static RequestMetaData stubRequest(String method, byte[] body, String contentType) {
         return new RequestMetaData() {
             @Override
             public String getContentType() {
-                return "application/x-www-form-urlencoded";
+                return contentType;
             }
 
             @Override
@@ -89,8 +133,7 @@ class ApiCaptureBodiesTest {
         };
     }
 
-    private static ResponseMetaData stubResponse(String body) {
-        byte[] bytes = body != null ? body.getBytes(StandardCharsets.UTF_8) : null;
+    private static ResponseMetaData stubResponse(byte[] bytes, String contentType) {
         return new ResponseMetaData() {
             @Override
             public int getStatus() {
@@ -99,7 +142,7 @@ class ApiCaptureBodiesTest {
 
             @Override
             public String getContentType() {
-                return "text/plain";
+                return contentType;
             }
 
             @Override

--- a/logbook/src/test/java/logbook/internal/capture/ApiCaptureHookTest.java
+++ b/logbook/src/test/java/logbook/internal/capture/ApiCaptureHookTest.java
@@ -1,0 +1,52 @@
+package logbook.internal.capture;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import logbook.proxy.ResponseMetaData;
+
+/**
+ * {@link ApiCaptureHook} のテスト。
+ */
+class ApiCaptureHookTest {
+
+    @Test
+    void shouldCaptureResponseSkips304() {
+        assertFalse(ApiCaptureHook.shouldCaptureResponse(
+                stubResponse(HttpURLConnection.HTTP_NOT_MODIFIED, null)));
+        assertTrue(ApiCaptureHook.shouldCaptureResponse(
+                stubResponse(HttpURLConnection.HTTP_OK, "")));
+        assertTrue(ApiCaptureHook.shouldCaptureResponse(
+                stubResponse(HttpURLConnection.HTTP_OK, "body")));
+        assertTrue(ApiCaptureHook.shouldCaptureResponse(null));
+    }
+
+    private static ResponseMetaData stubResponse(int status, String body) {
+        byte[] bytes = body != null ? body.getBytes(StandardCharsets.UTF_8) : null;
+        return new ResponseMetaData() {
+            @Override
+            public int getStatus() {
+                return status;
+            }
+
+            @Override
+            public String getContentType() {
+                return null;
+            }
+
+            @Override
+            public Optional<java.io.InputStream> getResponseBody() {
+                if (bytes == null) {
+                    return Optional.empty();
+                }
+                return Optional.of(new java.io.ByteArrayInputStream(bytes));
+            }
+        };
+    }
+}

--- a/logbook/src/test/java/logbook/internal/capture/ApiCapturePolicyTest.java
+++ b/logbook/src/test/java/logbook/internal/capture/ApiCapturePolicyTest.java
@@ -3,12 +3,27 @@ package logbook.internal.capture;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.InputStream;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
  * {@link ApiCapturePolicy} のテスト。
  */
 class ApiCapturePolicyTest {
+
+    @BeforeEach
+    void setUp() throws Exception {
+        try (InputStream in = getClass().getResourceAsStream(
+                "/logbook/capture/api-capture-rules-test.properties")) {
+            if (in == null) {
+                throw new IllegalStateException("test rules resource missing");
+            }
+            ApiCapturePolicy.replaceRulesForTest(ApiCaptureRulesLoader.parse(in));
+        }
+    }
 
     @Test
     void capturesKcsapi() {
@@ -17,19 +32,34 @@ class ApiCapturePolicyTest {
     }
 
     @Test
-    void skipsNonKcsapi() {
+    void capturesKcs2ClientAssets() {
+        assertTrue(ApiCapturePolicy.shouldCapture("/kcs2/js/main.js?version=6.3.2.0"));
+        assertTrue(ApiCapturePolicy.shouldCapture("/kcs2/version.json"));
+    }
+
+    @Test
+    void skipsNonTargetPaths() {
         assertFalse(ApiCapturePolicy.shouldCapture("/assets/foo.png"));
         assertFalse(ApiCapturePolicy.shouldCapture(null));
+        assertFalse(ApiCapturePolicy.shouldCapture("/kcs2/hc.html"));
+        assertFalse(ApiCapturePolicy.shouldCapture(
+                "/kcs2/index.php?version=6.3.2.0&api_token=secret"));
+        assertFalse(ApiCapturePolicy.shouldCapture("/kcs2/img/common/common_main.json?version=6.3.2.0"));
+        assertFalse(ApiCapturePolicy.shouldCapture("/kcs2/img/battle/battle_main.png?version=6.3.2.0"));
+        assertFalse(ApiCapturePolicy.shouldCapture("/kcs2/resources/ship/banner/0593_6277.png"));
     }
 
     @Test
     void registerAdditionalRule() {
         ApiCaptureTargetRule rule = ApiCaptureTargetRule.prefix("/custom-api/");
         ApiCapturePolicy.register(rule);
-        try {
-            assertTrue(ApiCapturePolicy.shouldCapture("/custom-api/foo"));
-        } finally {
-            // CopyOnWriteArrayList から削除 API が無いため、他テストへの影響は許容
-        }
+        assertTrue(ApiCapturePolicy.shouldCapture("/custom-api/foo"));
+    }
+
+    @Test
+    void emptyRulesCaptureNothing() {
+        ApiCapturePolicy.replaceRulesForTest(List.of());
+        assertFalse(ApiCapturePolicy.shouldCapture("/kcsapi/api_port/port"));
+        assertFalse(ApiCapturePolicy.shouldCapture("/kcs2/js/main.js"));
     }
 }

--- a/logbook/src/test/java/logbook/internal/capture/ApiCaptureRulesLoaderTest.java
+++ b/logbook/src/test/java/logbook/internal/capture/ApiCaptureRulesLoaderTest.java
@@ -1,0 +1,51 @@
+package logbook.internal.capture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link ApiCaptureRulesLoader} のテスト。
+ */
+class ApiCaptureRulesLoaderTest {
+
+    @Test
+    void parsesPrefixKeysInNumericOrder() throws Exception {
+        String text = """
+                prefix.10=/later/
+                prefix.2=/kcs2/js/
+                prefix.1=/kcsapi/
+                """;
+        List<ApiCaptureTargetRule> rules = ApiCaptureRulesLoader.parse(
+                new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8)));
+        assertEquals(3, rules.size());
+        assertTrue(rules.get(0).matches("/kcsapi/api_port/port"));
+        assertTrue(rules.get(1).matches("/kcs2/js/main.js"));
+        assertTrue(rules.get(2).matches("/later/x"));
+        assertFalse(rules.get(0).matches("/kcs2/js/main.js"));
+    }
+
+    @Test
+    void emptyPropertiesYieldNoRules() {
+        assertTrue(ApiCaptureRulesLoader.parse(new Properties()).isEmpty());
+    }
+
+    @Test
+    void ignoresBlankPrefixValues() throws Exception {
+        String text = """
+                prefix.1=/kcsapi/
+                prefix.2=
+                """;
+        List<ApiCaptureTargetRule> rules = ApiCaptureRulesLoader.parse(
+                new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8)));
+        assertEquals(1, rules.size());
+        assertTrue(rules.get(0).matches("/kcsapi/x"));
+    }
+}

--- a/logbook/src/test/java/logbook/internal/capture/ApiCaptureSegmentStoreTest.java
+++ b/logbook/src/test/java/logbook/internal/capture/ApiCaptureSegmentStoreTest.java
@@ -149,7 +149,11 @@ class ApiCaptureSegmentStoreTest {
                 requestId,
                 "POST",
                 "/kcsapi/api_port/port",
+                "/kcsapi/api_port/port",
+                "text/plain",
                 null,
-                "svdata={}");
+                null,
+                "svdata={}",
+                ApiCaptureBodies.ENCODING_UTF8);
     }
 }

--- a/logbook/src/test/java/logbook/internal/capture/ApiCaptureWriterTest.java
+++ b/logbook/src/test/java/logbook/internal/capture/ApiCaptureWriterTest.java
@@ -78,19 +78,26 @@ class ApiCaptureWriterTest {
                 "req-123",
                 "POST",
                 "/kcsapi/api_port/port",
+                "/kcsapi/api_port/port?api_verno=1",
+                "text/plain",
                 "api_token=abc",
-                responseBody);
+                ApiCaptureBodies.ENCODING_UTF8,
+                responseBody,
+                ApiCaptureBodies.ENCODING_UTF8);
 
         assertTrue(this.service.enqueue(record));
         this.service.flush();
 
         JsonObject envelope = readFirstEnvelope(findSegment(captureDir));
-        assertEquals(1, envelope.getInt("v"));
+        assertEquals(3, envelope.getInt("v"));
         assertEquals("req-123", envelope.getString("requestId"));
         assertEquals("POST", envelope.getString("method"));
         assertEquals("/kcsapi/api_port/port", envelope.getString("uriPath"));
-        assertFalse(envelope.containsKey("uri"));
+        assertEquals("/kcsapi/api_port/port?api_verno=1", envelope.getString("uri"));
+        assertEquals("text/plain", envelope.getString("contentType"));
+        assertEquals(ApiCaptureBodies.ENCODING_UTF8, envelope.getString("requestEncoding"));
         assertEquals("api_token=abc", envelope.getString("request"));
+        assertEquals(ApiCaptureBodies.ENCODING_UTF8, envelope.getString("responseEncoding"));
         assertEquals(responseBody, envelope.getString("response"));
         assertTrue(envelope.containsKey("capturedAt"));
     }
@@ -104,13 +111,44 @@ class ApiCaptureWriterTest {
                 "req-no-body",
                 "POST",
                 "/kcsapi/api_port/port",
+                "/kcsapi/api_port/port",
+                "text/plain",
                 null,
-                "svdata={}")));
+                null,
+                "svdata={}",
+                ApiCaptureBodies.ENCODING_UTF8)));
         this.service.flush();
 
         JsonObject envelope = readFirstEnvelope(findSegment(captureDir));
         assertFalse(envelope.containsKey("request"));
+        assertFalse(envelope.containsKey("requestEncoding"));
         assertEquals("svdata={}", envelope.getString("response"));
+        assertEquals(ApiCaptureBodies.ENCODING_UTF8, envelope.getString("responseEncoding"));
+    }
+
+    @Test
+    void writesBase64ResponseForBinaryBody() throws Exception {
+        Path captureDir = tempDir.resolve("captures");
+        this.service = newService(captureDir, () -> true);
+
+        String base64 = java.util.Base64.getEncoder().encodeToString(new byte[] { (byte) 0x89, 0x50, 0x4E, 0x47 });
+        assertTrue(this.service.enqueue(new ApiCaptureRecord(
+                "req-bin",
+                "GET",
+                "/kcs2/resources/map/007/02_image.png",
+                "/kcs2/resources/map/007/02_image.png",
+                "image/png",
+                null,
+                null,
+                base64,
+                ApiCaptureBodies.ENCODING_BASE64)));
+        this.service.flush();
+
+        JsonObject envelope = readFirstEnvelope(findSegment(captureDir));
+        assertEquals(3, envelope.getInt("v"));
+        assertEquals("image/png", envelope.getString("contentType"));
+        assertEquals(ApiCaptureBodies.ENCODING_BASE64, envelope.getString("responseEncoding"));
+        assertEquals(base64, envelope.getString("response"));
     }
 
     @Test
@@ -127,12 +165,24 @@ class ApiCaptureWriterTest {
     @Test
     void envelopeOmitsNullRequest() {
         ApiCaptureEnvelope envelope = ApiCaptureEnvelope.from(
-                new ApiCaptureRecord("id", "POST", "/kcsapi/x", null, "svdata={}"),
+                new ApiCaptureRecord(
+                        "id",
+                        "POST",
+                        "/kcsapi/x",
+                        "/kcsapi/x",
+                        null,
+                        null,
+                        null,
+                        "svdata={}",
+                        ApiCaptureBodies.ENCODING_UTF8),
                 Instant.parse("2026-07-12T00:00:00Z"));
         String json = JsonMappers.MAPPER.writeValueAsString(envelope);
         assertFalse(json.contains("\"request\""));
+        assertFalse(json.contains("\"requestEncoding\""));
         assertTrue(json.contains("\"response\":\"svdata={}\""));
+        assertTrue(json.contains("\"responseEncoding\":\"utf8\""));
         assertTrue(json.contains("\"capturedAt\":\"2026-07-12T00:00:00Z\""));
+        assertTrue(json.contains("\"v\":3"));
     }
 
     @Test
@@ -169,8 +219,12 @@ class ApiCaptureWriterTest {
                 requestId,
                 "POST",
                 "/kcsapi/api_port/port",
+                "/kcsapi/api_port/port",
+                "text/plain",
                 null,
-                "svdata={}");
+                null,
+                "svdata={}",
+                ApiCaptureBodies.ENCODING_UTF8);
     }
 
     private static Path findSegment(Path captureDir) throws Exception {

--- a/logbook/src/test/resources/logbook/capture/api-capture-rules-test.properties
+++ b/logbook/src/test/resources/logbook/capture/api-capture-rules-test.properties
@@ -1,0 +1,4 @@
+# API キャプチャ対象 URI（単体テスト用）
+prefix.1=/kcsapi/
+prefix.2=/kcs2/js/
+prefix.3=/kcs2/version.json


### PR DESCRIPTION
#### 変更内容
開発用キャプチャをテキスト API 以外（JS / イメージ（バイナリ））に対応
キャプチャ対象をプロパティで指定出来るように変更
配布では空ルールとする

#### 関連するIssue
Fixes #239

