### PR TITLE
JsonMapperのデフォルト変更とそれに伴う修正

### DIFF
--- a/logbook/src/main/java/logbook/internal/AppQuestConditionLoader.java
+++ b/logbook/src/main/java/logbook/internal/AppQuestConditionLoader.java
@@ -77,6 +77,7 @@ public final class AppQuestConditionLoader {
 
     /**
      * 任務条件 JSON を AppQuestCondition にデシリアライズする。
+     * ストリームのクローズは呼び出し元の責務。
      */
     public static AppQuestCondition load(InputStream is) throws IOException {
         return JsonMappers.READER_WITH_COMMENTS

--- a/logbook/src/main/java/logbook/internal/BattleLogs.java
+++ b/logbook/src/main/java/logbook/internal/BattleLogs.java
@@ -71,9 +71,9 @@ public class BattleLogs {
 
     /**
      * InputStream から戦闘ログをデシリアライズします。
-     * GZIP やパスは扱わず、呼び出し元でストリームを組み立てること。
+     * GZIP やパスは扱わず、呼び出し元でストリームを組み立て・クローズすること。
      *
-     * @param in JSON 入力ストリーム（UTF-8 想定）
+     * @param in JSON 入力ストリーム（UTF-8 想定）。クローズは呼び出し元の責務
      * @return 戦闘ログ
      * @throws IOException 入出力例外
      */
@@ -103,15 +103,17 @@ public class BattleLogs {
             List<Path> paths = tryReadPaths(dateString);
             for (Path path : paths) {
                 if (Files.isReadable(path)) {
-                    // readValue(InputStream) に渡したストリームは Jackson が閉じるため close 不要（StreamReadFeature.AUTO_CLOSE_SOURCE デフォルト true）
-                    InputStream in = new BufferedInputStream(Files.newInputStream(path));
-                    in.mark(1024);
-                    int header = (in.read() | (in.read() << 8));
-                    in.reset();
-                    if (header == GZIPInputStream.GZIP_MAGIC) {
-                        in = new GZIPInputStream(in);
+                    try (InputStream fileIn = new BufferedInputStream(Files.newInputStream(path))) {
+                        fileIn.mark(1024);
+                        int header = (fileIn.read() | (fileIn.read() << 8));
+                        fileIn.reset();
+                        if (header == GZIPInputStream.GZIP_MAGIC) {
+                            try (InputStream in = new GZIPInputStream(fileIn)) {
+                                return fromJson(in);
+                            }
+                        }
+                        return fromJson(fileIn);
                     }
-                    return fromJson(in);
                 }
             }
         } catch (Exception e) {

--- a/logbook/src/main/java/logbook/internal/JsonMappers.java
+++ b/logbook/src/main/java/logbook/internal/JsonMappers.java
@@ -1,5 +1,6 @@
 package logbook.internal;
 
+import tools.jackson.core.StreamReadFeature;
 import tools.jackson.core.json.JsonReadFeature;
 import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.ObjectReader;
@@ -9,11 +10,16 @@ import tools.jackson.databind.json.JsonMapper;
 /**
  * アプリケーション全体で共有する JsonMapper と ObjectReader の定数です。
  * Jackson3 の JSON 読み書きはここで定義した定数を使用してください。
+ * <p>
+ * {@link StreamReadFeature#AUTO_CLOSE_SOURCE} は無効です。
+ * {@code InputStream} を渡す場合は、呼び出し側の try-with-resources で閉じてください。
+ * </p>
  */
 public final class JsonMappers {
 
     /** デフォルト設定の JsonMapper（strict: 未知プロパティで失敗）。書き込みおよび strict な読み込みに使用。 */
     public static final JsonMapper MAPPER = JsonMapper.builder()
+                .disable(StreamReadFeature.AUTO_CLOSE_SOURCE)           // 呼び出し側で InputStream を閉じる
                 .disable(EnumFeature.WRITE_ENUMS_USING_TO_STRING)       // 列挙型をtoString()で書き込まない
                 .disable(EnumFeature.READ_ENUMS_USING_TO_STRING)        // 列挙型をtoString()で読み込まない
                 .build();

--- a/logbook/src/main/java/logbook/internal/Mapping.java
+++ b/logbook/src/main/java/logbook/internal/Mapping.java
@@ -28,7 +28,7 @@ public class Mapping {
     }
 
     private static Map<String, String> loadMapping() {
-        // readValue(InputStream) に渡したストリームは Jackson が閉じるため、load 側の try-with-resources との二重 close は問題ない
+        // InputStream のクローズは GameDataLoader.load 側の try-with-resources に任せる
         return GameDataLoader.load(
                 GameDataPaths.MAPPING,
                 GameDataPaths.CLASSPATH_MAPPING,

--- a/logbook/src/main/java/logbook/internal/MissionConditionLoader.java
+++ b/logbook/src/main/java/logbook/internal/MissionConditionLoader.java
@@ -15,6 +15,7 @@ final class MissionConditionLoader {
 
     /**
      * 遠征条件 JSON を読み込み、MissionCondition に変換して返す。
+     * ストリームのクローズは呼び出し元の責務。
      */
     static MissionCondition load(InputStream is) throws IOException {
         MissionCondition record = JsonMappers.READER_WITH_COMMENTS

--- a/logbook/src/main/java/logbook/internal/Missions.java
+++ b/logbook/src/main/java/logbook/internal/Missions.java
@@ -58,14 +58,14 @@ public class Missions {
             mission = Missions.getMission(34);
         }
 
-        // readValue(InputStream) に渡したストリームは Jackson が閉じるため close 不要（StreamReadFeature.AUTO_CLOSE_SOURCE デフォルト true）
-        InputStream is = PluginServices
-                .getResourceAsStream("logbook/mission/" + mission.getMapareaId() + "/" + mission.getDispNo() + ".json");
-        if (is == null) {
-            return Optional.empty();
+        try (InputStream is = PluginServices
+                .getResourceAsStream("logbook/mission/" + mission.getMapareaId() + "/" + mission.getDispNo() + ".json")) {
+            if (is == null) {
+                return Optional.empty();
+            }
+            MissionCondition condition = MissionConditionLoader.load(is);
+            return Optional.ofNullable(condition);
         }
-        MissionCondition condition = MissionConditionLoader.load(is);
-        return Optional.ofNullable(condition);
     }
 
     /**

--- a/logbook/src/main/java/logbook/internal/ShipSupplementalLoader.java
+++ b/logbook/src/main/java/logbook/internal/ShipSupplementalLoader.java
@@ -22,6 +22,7 @@ final class ShipSupplementalLoader {
 
     /**
      * 艦娘付加情報 JSON を読み込み、ID をキーとした Map を返す。
+     * ストリームのクローズは呼び出し元の責務。
      */
     static Map<Integer, ShipSupplementalInfo> loadSupplementalMap(InputStream is) {
         try {

--- a/logbook/src/main/java/logbook/internal/Ships.java
+++ b/logbook/src/main/java/logbook/internal/Ships.java
@@ -1,5 +1,6 @@
 package logbook.internal;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -181,9 +182,16 @@ public class Ships {
         SLOTITEM_TYPE_TP_MAP.put(SlotItemType.特型内火艇, 2);
         SLOTITEM_TYPE_TP_MAP.put(SlotItemType.戦闘糧食, 1);
 
-        // 付加的な情報の読み込み
-        InputStream is = PluginServices.getResourceAsStream("logbook/supplemental/ships.json");
-        ships = is != null ? ShipSupplementalLoader.loadSupplementalMap(is) : Collections.emptyMap();
+        // 付加的な情報の読み込み（InputStream は呼び出し側で閉じる）
+        Map<Integer, ShipSupplementalInfo> loaded = Collections.emptyMap();
+        try (InputStream is = PluginServices.getResourceAsStream("logbook/supplemental/ships.json")) {
+            if (is != null) {
+                loaded = ShipSupplementalLoader.loadSupplementalMap(is);
+            }
+        } catch (IOException e) {
+            LoggerHolder.get().warn("艦娘付加情報ストリームのクローズに失敗しました", e);
+        }
+        ships = loaded;
     }
 
     private Ships() {

--- a/logbook/src/main/java/logbook/internal/gamedata/GameDataLoader.java
+++ b/logbook/src/main/java/logbook/internal/gamedata/GameDataLoader.java
@@ -230,6 +230,7 @@ public final class GameDataLoader {
 
     /**
      * ストリームからマニフェストを読みます。
+     * ストリームのクローズは呼び出し元の責務。
      *
      * @param is 入力
      * @return マニフェスト

--- a/logbook/src/test/java/logbook/internal/JsonMappersTest.java
+++ b/logbook/src/test/java/logbook/internal/JsonMappersTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import tools.jackson.core.JacksonException;
+import tools.jackson.core.StreamReadFeature;
 import tools.jackson.databind.cfg.DateTimeFeature;
 
 /**
@@ -181,6 +182,16 @@ class JsonMappersTest {
                 JsonMappers.STRICT_CREATOR_READER_WITH_COMMENTS
                         .forType(NameValueBean.class)
                         .readValue(jsonMissingValue));
+    }
+
+    /**
+     * InputStream は呼び出し側で閉じる方針のため、AUTO_CLOSE_SOURCE は無効。
+     */
+    @Test
+    void mapperDoesNotAutoCloseSource() {
+        assertFalse(JsonMappers.MAPPER.isEnabled(StreamReadFeature.AUTO_CLOSE_SOURCE));
+        assertFalse(JsonMappers.LENIENT_READER.isEnabled(StreamReadFeature.AUTO_CLOSE_SOURCE));
+        assertFalse(JsonMappers.READER_WITH_COMMENTS.isEnabled(StreamReadFeature.AUTO_CLOSE_SOURCE));
     }
 
     /**


### PR DESCRIPTION
#### 変更内容
Jackson3のデフォルトの読み込み時AUTO_CLOSE_SOURCEをオフに変更
読み込み処理でCLOSE処理の追加

#### 関連するIssue
Fixes #243

