### PR TITLE
未対応キーと意図的に実装しない物を管理出来るように修正

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -267,11 +267,11 @@ API レスポンス JSON のうち、bean / ハンドラが把握していない
 ### 仕組み
 
 1. ハンドラ入口で `ApiSchemaLog.openRequest(uriPath, requestId, handlerClass)` によりリクエスト文脈を MDC に載せる
-2. `JsonHelper.bind(json).at("…").reportUnknown()` で、バインドしなかったキーを報告する
+2. `JsonHelper.bind(json).at("…").set…(...).ignore(…).reportUnknown()` で、バインドも ignore もしなかったキーを報告する
 3. ハンドラ直下など bind しない箇所は `JsonHelper.reportUnknownKeys(json, jsonPath, knownKeys)` を使う
 4. 同一 `(uriPath, jsonPath, field)` はプロセス内で 1 回だけ報告する（重複抑制）
 
-**既知キーの意味**: 「処理するキー」だけでなく、「未対応でよいと確認済みのキー」も含める。`ApiStart2` では `HANDLED_API_DATA_KEYS`（Collection 反映）と `IGNORED_API_DATA_KEYS`（意図的未対応）の和を `KNOWN_API_DATA_KEYS` として渡し、**新規追加キーだけ**がログに出る。
+**既知キーの意味**: 「処理するキー」だけでなく、「未対応でよいと確認済みのキー」も含める。bind では `set` が前者、`ignore` が後者。`ApiStart2` の `api_data` では `HANDLED_API_DATA_KEYS` と `IGNORED_API_DATA_KEYS` の和を `KNOWN_API_DATA_KEYS` として渡し、**新規追加キーだけ**がログに出る。
 
 ### MDC キー一覧
 
@@ -289,7 +289,7 @@ API レスポンス JSON のうち、bean / ハンドラが把握していない
 ### 他 API への追加手順（概要）
 
 1. `accept` 内を `ApiSchemaLog.openRequest(...)` で囲む
-2. bean の `JsonHelper.bind` に `.at("…").reportUnknown()` を付ける
+2. bean の `JsonHelper.bind` に `.at("…")` と、使うキーは `.set…`、意図的未対応は `.ignore(…)`、末尾に `.reportUnknown()` を付ける
 3. ハンドラ直下のオブジェクトは `reportUnknownKeys` と `KNOWN`（対応済み ∪ 意図的未対応）を用意する
 
 ---

--- a/logbook/src/main/java/logbook/bean/ShipMst.java
+++ b/logbook/src/main/java/logbook/bean/ShipMst.java
@@ -209,6 +209,13 @@ public class ShipMst implements Serializable {
                 .setInteger("api_afterbull", bean::setAfterbull)
                 .setInteger("api_fuel_max", bean::setFuelMax)
                 .setInteger("api_bull_max", bean::setBullMax)
+                .ignore(
+                        "api_buildtime", // 建造時間（分）
+                        "api_broken", // 解体時に得られる資材
+                        "api_powup", // 近代化改修の元になった際に上がるパラメータ
+                        "api_backs", // レアリティ（背景）
+                        "api_getmes", // 入手時メッセージ
+                        "api_voicef") // ボイスフラグ
                 .reportUnknown();
         return bean;
     }

--- a/logbook/src/main/java/logbook/bean/Shipgraph.java
+++ b/logbook/src/main/java/logbook/bean/Shipgraph.java
@@ -98,6 +98,11 @@ public class Shipgraph {
                 .setStringList("api_version", bean::setVersion)
                 .setIntegerList("api_weda", bean::setWeda)
                 .setIntegerList("api_wedb", bean::setWedb)
+                .ignore(
+                        "api_pab", // その他オフセット？
+                        "api_wedc", // 結婚枠オフセット C
+                        "api_wedd", // 結婚枠オフセット D
+                        "api_sp_flag") // 特殊表示フラグ？
                 .reportUnknown();
 
         return bean;

--- a/logbook/src/main/java/logbook/bean/SlotitemMst.java
+++ b/logbook/src/main/java/logbook/bean/SlotitemMst.java
@@ -183,6 +183,10 @@ public class SlotitemMst implements Serializable {
                 .setInteger("api_rare", bean::setRare)
                 .setInteger("api_cost", bean::setCost)
                 .setInteger("api_distance", bean::setDistance)
+                .ignore(
+                        "api_broken", // 廃棄資材
+                        "api_usebull", // 不明
+                        "api_version") // リソースバージョン
                 .reportUnknown();
         return bean;
     }

--- a/logbook/src/main/java/logbook/bean/UseitemMst.java
+++ b/logbook/src/main/java/logbook/bean/UseitemMst.java
@@ -43,6 +43,10 @@ public class UseitemMst implements Serializable {
                 .setInteger("api_id", bean::setId)
                 .setString("api_name", bean::setName)
                 .setStringList("api_description", bean::setDescription)
+                .ignore(
+                        "api_usetype", // 使用種別
+                        "api_category", // カテゴリ
+                        "api_price") // 価格（表示用）
                 .reportUnknown();
         return bean;
     }

--- a/logbook/src/main/java/logbook/internal/JsonHelper.java
+++ b/logbook/src/main/java/logbook/internal/JsonHelper.java
@@ -622,7 +622,25 @@ public final class JsonHelper {
         }
 
         /**
-         * {@link #at(String)} で指定した位置について、バインドしなかったキーを報告する。
+         * 意図的に読み捨てるキーを既知扱いにする（bean には載せない）。
+         * {@link #reportUnknown()} の報告対象から除外する。
+         *
+         * @param keys キー名
+         * @return {@link Bind}
+         */
+        public Bind ignore(String... keys) {
+            if (keys != null) {
+                for (String key : keys) {
+                    if (key != null) {
+                        this.boundKeys.add(key);
+                    }
+                }
+            }
+            return this;
+        }
+
+        /**
+         * {@link #at(String)} で指定した位置について、バインドも ignore もしなかったキーを報告する。
          *
          * @return {@link Bind}
          */

--- a/logbook/src/test/java/logbook/internal/api/JsonHelperBindSchemaTest.java
+++ b/logbook/src/test/java/logbook/internal/api/JsonHelperBindSchemaTest.java
@@ -74,6 +74,8 @@ class JsonHelperBindSchemaTest {
                 .add("api_afterbull", 0)
                 .add("api_fuel_max", 10)
                 .add("api_bull_max", 10)
+                .add("api_buildtime", 30)
+                .add("api_broken", Json.createArrayBuilder().add(1).add(1).add(1).add(0))
                 .add("api_new_field", 99)
                 .build();
 
@@ -91,6 +93,31 @@ class JsonHelperBindSchemaTest {
         assertEquals("api_data.api_mst_ship[]", events.get(0).getMDCPropertyMap().get(ApiSchemaLog.MDC_JSON_PATH));
         assertEquals("/kcsapi/api_start2/getData",
                 events.get(0).getMDCPropertyMap().get(ApiSchemaLog.MDC_URI_PATH));
+    }
+
+    @Test
+    void ignorePreventsUnknownReport() {
+        JsonObject json = Json.createObjectBuilder()
+                .add("known", 1)
+                .add("ignored", 2)
+                .add("unknown", 3)
+                .build();
+
+        try (ApiSchemaLog.Scope scope = ApiSchemaLog.openRequest(
+                "/kcsapi/test", "req-ignore", "logbook.internal.api.JsonHelperBindSchemaTest")) {
+            JsonHelper.bind(json)
+                    .at("test")
+                    .setInteger("known", value -> {
+                    })
+                    .ignore("ignored")
+                    .reportUnknown();
+        }
+
+        List<ILoggingEvent> events = appender.list.stream()
+                .filter(event -> "api unknown field".equals(event.getMessage()))
+                .toList();
+        assertEquals(1, events.size());
+        assertEquals("unknown", events.get(0).getMDCPropertyMap().get(ApiSchemaLog.MDC_FIELD));
     }
 
     @Test


### PR DESCRIPTION
#### 変更内容
意図的にbeanに実装しない物を未対応としないように設定出来るように修正

#### 関連するIssue
Fixes #249

