### PR TITLE
未定義キーの検出の拡張

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -247,7 +247,18 @@ API レスポンス JSON のうち、bean / ハンドラが把握していない
 
 一般向け（同梱 `logback.xml`）ではこのロガーに appender を付けないため出力されません。開発ホストでは `dev/logback/logback.xml` の JSON appender を使います。
 
-対象 API は段階的に増やします。現状は `/kcsapi/api_start2/getData`（`ApiStart2` と各マスタ bean）です。
+### 対応範囲
+
+| 区分 | 状態 | 内容 |
+|------|------|------|
+| リクエスト文脈 | 対応済み | `APIListener.createTask` が全ハンドラで `ApiSchemaLog.openRequest`（uri / requestId / handlerClass） |
+| `api_start2/getData` | 対応済み | `ApiStart2` の `api_data` KNOWN + 各マスタ bean の `at` / `ignore` / `reportUnknown` |
+| 母港・メンバー・日常系 | 対応済み（第1波） | 下記 bean / ハンドラ。`api_data` を選択読取する主要ハンドラは KNOWN 付き |
+| 戦闘系 | **未対応（第2波）** | `BattleTypes`・各戦闘 bean・戦闘結果。別 Issue で `at` / `reportUnknown` と ignore 整理 |
+
+**第1波の bean（`at` + `reportUnknown`）**: `Basic`, `Ship`, `SlotItem`, `Useitem`, `DeckPort`, `Material`, `Ndock`, `Kdock`, `MapStartNext`, `MissionResult`, `QuestList`, `Createitem`, `Mapinfo`, `MapTypes`（および既存の start2 マスタ bean）
+
+**第1波のハンドラ `api_data` KNOWN**: `ApiStart2`, `ApiPortPort`, `ApiGetMemberRequireInfo`, `ApiGetMemberShipDeck`, `ApiGetMemberShip3`, `ApiGetMemberMapinfo`
 
 ### 有効化
 
@@ -266,12 +277,12 @@ API レスポンス JSON のうち、bean / ハンドラが把握していない
 
 ### 仕組み
 
-1. ハンドラ入口で `ApiSchemaLog.openRequest(uriPath, requestId, handlerClass)` によりリクエスト文脈を MDC に載せる
+1. `APIListener.createTask` が `ApiSchemaLog.openRequest(uriPath, requestId, handlerClass)` でリクエスト文脈を MDC に載せる（ハンドラ側で個別に open しない）
 2. `JsonHelper.bind(json).at("…").set…(...).ignore(…).reportUnknown()` で、バインドも ignore もしなかったキーを報告する
 3. ハンドラ直下など bind しない箇所は `JsonHelper.reportUnknownKeys(json, jsonPath, knownKeys)` を使う
 4. 同一 `(uriPath, jsonPath, field)` はプロセス内で 1 回だけ報告する（重複抑制）
 
-**既知キーの意味**: 「処理するキー」だけでなく、「未対応でよいと確認済みのキー」も含める。bind では `set` が前者、`ignore` が後者。`ApiStart2` の `api_data` では `HANDLED_API_DATA_KEYS` と `IGNORED_API_DATA_KEYS` の和を `KNOWN_API_DATA_KEYS` として渡し、**新規追加キーだけ**がログに出る。
+**既知キーの意味**: 「処理するキー」だけでなく、「未対応でよいと確認済みのキー」も含める。bind では `set` が前者、`ignore` が後者。ハンドラの `api_data` では `HANDLED_API_DATA_KEYS` と `IGNORED_API_DATA_KEYS` の和を `KNOWN_API_DATA_KEYS` として渡し、**新規追加キーだけ**がログに出る。
 
 ### MDC キー一覧
 
@@ -288,11 +299,12 @@ API レスポンス JSON のうち、bean / ハンドラが把握していない
 
 ### 他 API への追加手順（概要）
 
-1. `accept` 内を `ApiSchemaLog.openRequest(...)` で囲む
+1. リクエスト文脈は `APIListener` 側で付与済み。ハンドラで `openRequest` を重ねない
 2. bean の `JsonHelper.bind` に `.at("…")` と、使うキーは `.set…`、意図的未対応は `.ignore(…)`、末尾に `.reportUnknown()` を付ける
 3. ハンドラ直下のオブジェクトは `reportUnknownKeys` と `KNOWN`（対応済み ∪ 意図的未対応）を用意する
+4. キャプチャ突合でノイズになった既存キーは `ignore` / `IGNORED_API_DATA_KEYS` に移す（start2 と同じ手順）
 
----
+戦闘系への展開は第2波（別 Issue）。`api_max_slotplus` など実装が必要な未知キーは別途対応する。
 
 ## API レスポンス記録（開発者向け）
 

--- a/logbook/src/main/java/logbook/api/ApiGetMemberMapinfo.java
+++ b/logbook/src/main/java/logbook/api/ApiGetMemberMapinfo.java
@@ -1,5 +1,9 @@
 package logbook.api;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import jakarta.json.JsonObject;
 
 import logbook.bean.Mapinfo;
@@ -14,10 +18,25 @@ import logbook.proxy.ResponseMetaData;
 @API("/kcsapi/api_get_member/mapinfo")
 public class ApiGetMemberMapinfo implements APIListenerSpi {
 
+    /** Collection 等に反映するキー */
+    private static final Set<String> HANDLED_API_DATA_KEYS = Set.of(
+            "api_map_info",
+            "api_air_base");
+
+    /** 未対応でよいと確認済みのキー */
+    private static final Set<String> IGNORED_API_DATA_KEYS = Set.of(
+            "api_air_base_expanded_info");
+
+    /** 未知キー報告の対象外（対応済み + 意図的未対応） */
+    private static final Set<String> KNOWN_API_DATA_KEYS = Stream
+            .concat(HANDLED_API_DATA_KEYS.stream(), IGNORED_API_DATA_KEYS.stream())
+            .collect(Collectors.toUnmodifiableSet());
+
     @Override
     public void accept(JsonObject json, RequestMetaData req, ResponseMetaData res) {
         JsonObject object = json.getJsonObject("api_data");
         if (object != null) {
+            JsonHelper.reportUnknownKeys(object, "api_data", KNOWN_API_DATA_KEYS);
             Mapinfo mapinfo = Mapinfo.get();
 
             // 海域

--- a/logbook/src/main/java/logbook/api/ApiGetMemberRequireInfo.java
+++ b/logbook/src/main/java/logbook/api/ApiGetMemberRequireInfo.java
@@ -1,5 +1,9 @@
 package logbook.api;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 
@@ -19,10 +23,32 @@ import logbook.proxy.ResponseMetaData;
 @API("/kcsapi/api_get_member/require_info")
 public class ApiGetMemberRequireInfo implements APIListenerSpi {
 
+    /** Collection 等に反映するキー */
+    private static final Set<String> HANDLED_API_DATA_KEYS = Set.of(
+            "api_basic",
+            "api_slot_item",
+            "api_useitem");
+
+    /** 未対応でよいと確認済みのキー */
+    private static final Set<String> IGNORED_API_DATA_KEYS = Set.of(
+            "api_unsetslot",
+            "api_kdock",
+            "api_furniture",
+            "api_extra_supply",
+            "api_oss_setting",
+            "api_skin_id",
+            "api_position_id");
+
+    /** 未知キー報告の対象外（対応済み + 意図的未対応） */
+    private static final Set<String> KNOWN_API_DATA_KEYS = Stream
+            .concat(HANDLED_API_DATA_KEYS.stream(), IGNORED_API_DATA_KEYS.stream())
+            .collect(Collectors.toUnmodifiableSet());
+
     @Override
     public void accept(JsonObject json, RequestMetaData req, ResponseMetaData res) {
         JsonObject data = json.getJsonObject("api_data");
         if (data != null) {
+            JsonHelper.reportUnknownKeys(data, "api_data", KNOWN_API_DATA_KEYS);
             this.apiBasic(data.getJsonObject("api_basic"));
             this.apiSlotItem(data.getJsonArray("api_slot_item"));
             // api_useitem (オプショナル)

--- a/logbook/src/main/java/logbook/api/ApiGetMemberShip3.java
+++ b/logbook/src/main/java/logbook/api/ApiGetMemberShip3.java
@@ -3,7 +3,9 @@ package logbook.api;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
@@ -23,10 +25,25 @@ import logbook.proxy.ResponseMetaData;
 @API("/kcsapi/api_get_member/ship3")
 public class ApiGetMemberShip3 implements APIListenerSpi {
 
+    /** Collection 等に反映するキー */
+    private static final Set<String> HANDLED_API_DATA_KEYS = Set.of(
+            "api_ship_data",
+            "api_deck_data");
+
+    /** 未対応でよいと確認済みのキー */
+    private static final Set<String> IGNORED_API_DATA_KEYS = Set.of(
+            "api_slot_data");
+
+    /** 未知キー報告の対象外（対応済み + 意図的未対応） */
+    private static final Set<String> KNOWN_API_DATA_KEYS = Stream
+            .concat(HANDLED_API_DATA_KEYS.stream(), IGNORED_API_DATA_KEYS.stream())
+            .collect(Collectors.toUnmodifiableSet());
+
     @Override
     public void accept(JsonObject json, RequestMetaData req, ResponseMetaData res) {
         JsonObject data = json.getJsonObject("api_data");
         if (data != null) {
+            JsonHelper.reportUnknownKeys(data, "api_data", KNOWN_API_DATA_KEYS);
             this.apiShipData(data.getJsonArray("api_ship_data"), req);
             this.apiDeckData(data.getJsonArray("api_deck_data"));
         }

--- a/logbook/src/main/java/logbook/api/ApiGetMemberShipDeck.java
+++ b/logbook/src/main/java/logbook/api/ApiGetMemberShipDeck.java
@@ -1,6 +1,9 @@
 package logbook.api;
 
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
@@ -20,10 +23,25 @@ import logbook.proxy.ResponseMetaData;
 @API("/kcsapi/api_get_member/ship_deck")
 public class ApiGetMemberShipDeck implements APIListenerSpi {
 
+    /** Collection 等に反映するキー */
+    private static final Set<String> HANDLED_API_DATA_KEYS = Set.of(
+            "api_ship_data",
+            "api_deck_data");
+
+    /** 未対応でよいと確認済みのキー */
+    private static final Set<String> IGNORED_API_DATA_KEYS = Set.of(
+            "api_slot_data");
+
+    /** 未知キー報告の対象外（対応済み + 意図的未対応） */
+    private static final Set<String> KNOWN_API_DATA_KEYS = Stream
+            .concat(HANDLED_API_DATA_KEYS.stream(), IGNORED_API_DATA_KEYS.stream())
+            .collect(Collectors.toUnmodifiableSet());
+
     @Override
     public void accept(JsonObject json, RequestMetaData req, ResponseMetaData res) {
         JsonObject data = json.getJsonObject("api_data");
         if (data != null) {
+            JsonHelper.reportUnknownKeys(data, "api_data", KNOWN_API_DATA_KEYS);
             this.apiShipData(data.getJsonArray("api_ship_data"));
             this.apiDeckData(data.getJsonArray("api_deck_data"));
         }

--- a/logbook/src/main/java/logbook/api/ApiPortPort.java
+++ b/logbook/src/main/java/logbook/api/ApiPortPort.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
@@ -46,10 +47,34 @@ import logbook.proxy.ResponseMetaData;
 @API("/kcsapi/api_port/port")
 public class ApiPortPort implements APIListenerSpi {
 
+    /** Collection 等に反映するキー */
+    private static final Set<String> HANDLED_API_DATA_KEYS = Set.of(
+            "api_basic",
+            "api_ship",
+            "api_deck_port",
+            "api_ndock",
+            "api_material",
+            "api_combined_flag",
+            "api_event_object");
+
+    /** 未対応でよいと確認済みのキー */
+    private static final Set<String> IGNORED_API_DATA_KEYS = Set.of(
+            "api_log",
+            "api_p_bgm_id",
+            "api_furniture_affect_items",
+            "api_parallel_quest_count",
+            "api_dest_ship_slot");
+
+    /** 未知キー報告の対象外（対応済み + 意図的未対応） */
+    private static final Set<String> KNOWN_API_DATA_KEYS = Stream
+            .concat(HANDLED_API_DATA_KEYS.stream(), IGNORED_API_DATA_KEYS.stream())
+            .collect(Collectors.toUnmodifiableSet());
+
     @Override
     public void accept(JsonObject json, RequestMetaData req, ResponseMetaData res) {
         JsonObject data = json.getJsonObject("api_data");
         if (data != null) {
+            JsonHelper.reportUnknownKeys(data, "api_data", KNOWN_API_DATA_KEYS);
             this.apiBasic(data.getJsonObject("api_basic"));
             this.apiShip(data.getJsonArray("api_ship"));
             this.apiDeckPort(data.getJsonArray("api_deck_port"));

--- a/logbook/src/main/java/logbook/api/ApiStart2.java
+++ b/logbook/src/main/java/logbook/api/ApiStart2.java
@@ -41,7 +41,6 @@ import logbook.bean.UseitemMstCollection;
 import logbook.internal.Config;
 import logbook.internal.JsonHelper;
 import logbook.internal.LoggerHolder;
-import logbook.internal.api.ApiSchemaLog;
 import logbook.proxy.RequestMetaData;
 import logbook.proxy.ResponseMetaData;
 
@@ -85,24 +84,21 @@ public class ApiStart2 implements APIListenerSpi {
 
     @Override
     public void accept(JsonObject json, RequestMetaData req, ResponseMetaData res) {
-        try (ApiSchemaLog.Scope ignored = ApiSchemaLog.openRequest(
-                req.getRequestURI(), req.getRequestId(), getClass().getName())) {
-            JsonObject data = json.getJsonObject("api_data");
-            if (data != null) {
-                JsonHelper.reportUnknownKeys(data, "api_data", KNOWN_API_DATA_KEYS);
-                this.apiMstShip(data.getJsonArray("api_mst_ship"));
-                this.apiMstShipgraph(data.getJsonArray("api_mst_shipgraph"));
-                this.apiMstSlotitemEquiptype(data.getJsonArray("api_mst_slotitem_equiptype"));
-                this.apiMstStype(data.getJsonArray("api_mst_stype"));
-                this.apiMstSlotitem(data.getJsonArray("api_mst_slotitem"));
-                this.apiMstUseitem(data.getJsonArray("api_mst_useitem"));
-                this.apiMstMission(data.getJsonArray("api_mst_mission"));
-                this.apiMstMaparea(data.getJsonArray("api_mst_maparea"));
-                this.apiMstMapinfo(data.getJsonArray("api_mst_mapinfo"));
-                this.store(data);
-            }
-            Config.getDefault().store();
+        JsonObject data = json.getJsonObject("api_data");
+        if (data != null) {
+            JsonHelper.reportUnknownKeys(data, "api_data", KNOWN_API_DATA_KEYS);
+            this.apiMstShip(data.getJsonArray("api_mst_ship"));
+            this.apiMstShipgraph(data.getJsonArray("api_mst_shipgraph"));
+            this.apiMstSlotitemEquiptype(data.getJsonArray("api_mst_slotitem_equiptype"));
+            this.apiMstStype(data.getJsonArray("api_mst_stype"));
+            this.apiMstSlotitem(data.getJsonArray("api_mst_slotitem"));
+            this.apiMstUseitem(data.getJsonArray("api_mst_useitem"));
+            this.apiMstMission(data.getJsonArray("api_mst_mission"));
+            this.apiMstMaparea(data.getJsonArray("api_mst_maparea"));
+            this.apiMstMapinfo(data.getJsonArray("api_mst_mapinfo"));
+            this.store(data);
         }
+        Config.getDefault().store();
     }
 
     /**

--- a/logbook/src/main/java/logbook/bean/Basic.java
+++ b/logbook/src/main/java/logbook/bean/Basic.java
@@ -65,6 +65,7 @@ public class Basic implements Serializable {
      */
     public static Basic updateBasic(Basic bean, JsonObject json) {
         JsonHelper.bind(json)
+                .at("api_data.api_basic")
                 .setString("api_comment", bean::setComment)
                 .setInteger("api_count_deck", bean::setCountDeck)
                 .setInteger("api_count_kdock", bean::setCountKdock)
@@ -77,7 +78,30 @@ public class Basic implements Serializable {
                 .setInteger("api_max_chara", bean::setMaxChara)
                 .setInteger("api_max_slotitem", bean::setMaxSlotitem)
                 .setInteger("api_medals", bean::setMedals)
-                .setString("api_nickname", bean::setNickname);
+                .setString("api_nickname", bean::setNickname)
+                .ignore(
+                        "api_member_id", // 提督 ID
+                        "api_nickname_id", // ニックネーム ID
+                        "api_active_flag", // アクティブフラグ
+                        "api_starttime", // セッション開始時刻らしき値
+                        "api_fleetname", // 連合艦隊名など
+                        "api_comment_id", // コメント ID
+                        "api_max_kagu", // 家具上限関連
+                        "api_playtime", // プレイ時間（クライアント用）
+                        "api_tutorial", // チュートリアルフラグ
+                        "api_furniture", // 設置家具 ID
+                        "api_st_win", // 出撃勝利数
+                        "api_st_lose", // 出撃敗北数
+                        "api_ms_count", // 遠征回数
+                        "api_ms_success", // 遠征成功数
+                        "api_pt_win", // 演習勝利数
+                        "api_pt_lose", // 演習敗北数
+                        "api_pt_challenged", // 演習被挑戦
+                        "api_pt_challenged_win", // 演習被挑戦勝利
+                        "api_firstflag", // 初回フラグ
+                        "api_tutorial_progress", // チュートリアル進捗
+                        "api_pvp") // 演習関連カウンタ
+                .reportUnknown();
         return bean;
     }
 

--- a/logbook/src/main/java/logbook/bean/Createitem.java
+++ b/logbook/src/main/java/logbook/bean/Createitem.java
@@ -59,10 +59,12 @@ public class Createitem implements Serializable {
         bean.setItem4(Integer.valueOf(req.getParameter("api_item4", "0")));
 
         JsonHelper.bind(json)
+                .at("api_data")
                 .setBoolean("api_create_flag", bean::setCreateFlag)
                 .setIntegerList("api_material", bean::setMaterial)
                 .set("api_get_items", bean::setGetItems, JsonHelper.toList(SlotItem::toSlotItem))
-                .set("api_unset_items", bean::setUnsetItems, JsonHelper.toList(UnsetItems::toUnsetItems));
+                .set("api_unset_items", bean::setUnsetItems, JsonHelper.toList(UnsetItems::toUnsetItems))
+                .reportUnknown();
 
         Ship secretary = null;
         DeckPort port = DeckPortCollection.get()
@@ -100,8 +102,10 @@ public class Createitem implements Serializable {
         public static UnsetItems toUnsetItems(JsonObject json) {
             UnsetItems bean = new UnsetItems();
             JsonHelper.bind(json)
+                    .at("api_data.api_unset_items[]")
                     .setInteger("api_type3", bean::setType3)
-                    .setIntegerList("api_unsetslot", bean::setUnsetslot);
+                    .setIntegerList("api_unsetslot", bean::setUnsetslot)
+                    .reportUnknown();
             return bean;
         }
     }

--- a/logbook/src/main/java/logbook/bean/DeckPort.java
+++ b/logbook/src/main/java/logbook/bean/DeckPort.java
@@ -83,11 +83,16 @@ public class DeckPort implements Serializable, Cloneable {
     public static DeckPort toDeckPort(JsonObject json) {
         DeckPort bean = new DeckPort();
         JsonHelper.bind(json)
+                .at("api_data.api_deck_port[]")
                 .setInteger("api_flagship", bean::setFlagship)
                 .setInteger("api_id", bean::setId)
                 .setLongList("api_mission", bean::setMission)
                 .setString("api_name", bean::setName)
-                .setIntegerList("api_ship", bean::setShip);
+                .setIntegerList("api_ship", bean::setShip)
+                .ignore(
+                        "api_member_id", // 提督 ID
+                        "api_name_id") // 艦隊名に紐づくID？
+                .reportUnknown();
         return bean;
     }
 

--- a/logbook/src/main/java/logbook/bean/Kdock.java
+++ b/logbook/src/main/java/logbook/bean/Kdock.java
@@ -56,6 +56,7 @@ public class Kdock implements Serializable {
     public static Kdock toKdock(JsonValue json) {
         Kdock bean = new Kdock();
         JsonHelper.bind((JsonObject) json)
+                .at("api_data.api_kdock[]")
                 .setInteger("api_id", bean::setId)
                 .setInteger("api_state", bean::setState)
                 .setInteger("api_created_ship_id", bean::setCreatedShipId)
@@ -65,7 +66,8 @@ public class Kdock implements Serializable {
                 .setInteger("api_item2", bean::setItem2)
                 .setInteger("api_item3", bean::setItem3)
                 .setInteger("api_item4", bean::setItem4)
-                .setInteger("api_item5", bean::setItem5);
+                .setInteger("api_item5", bean::setItem5)
+                .reportUnknown();
         return bean;
     }
 }

--- a/logbook/src/main/java/logbook/bean/MapStartNext.java
+++ b/logbook/src/main/java/logbook/bean/MapStartNext.java
@@ -118,6 +118,7 @@ public class MapStartNext implements Serializable {
     public static MapStartNext toMapStartNext(JsonObject json) {
         MapStartNext bean = new MapStartNext();
         JsonHelper.bind(json)
+                .at("api_data")
                 .setInteger("api_rashin_flg", bean::setRashinFlg)
                 .setInteger("api_rashin_id", bean::setRashinId)
                 .setInteger("api_maparea_id", bean::setMapareaId)
@@ -139,7 +140,18 @@ public class MapStartNext implements Serializable {
                 .setInteger("api_from_no", bean::setFromNo)
                 .set("api_destruction_battle", bean::setDestructionBattle, DestructionBattle::toDestructionBattle)
                 .setInteger("api_m1", bean::setM1)
-                .setInteger("api_m2", bean::setM2);
+                .setInteger("api_m2", bean::setM2)
+                .ignore(
+                        "api_cell_data", // マップセル一覧（start・クライアント描画用）
+                        "api_airsearch", // 索敵機演出
+                        "api_limit_state", // 制限状態（観測は常に 0）
+                        "api_e_deck_info", // 敵編成プレビュー
+                        "api_ration_flag", // 給糧関連（観測は常に 0。要再検討）
+                        "api_cell_flavor", // セル文言（クライアント表示）
+                        "api_itemget_eo_comment", // 1-6 EO 資材コメント
+                        "api_itemget_eo_result", // 1-6 EO 最終クリア報酬（他 EO は battleresult）
+                        "api_get_eo_rate") // 1-6 EO 最終クリア戦果（他 EO は battleresult）
+                .reportUnknown();
         return bean;
     }
 
@@ -164,9 +176,11 @@ public class MapStartNext implements Serializable {
         public static DestructionBattle toDestructionBattle(JsonObject json) {
             DestructionBattle bean = new DestructionBattle();
             JsonHelper.bind(json)
+                    .at("api_data.api_destruction_battle")
                     .setInteger("api_lost_kind", bean::setLostKind)
                     .setInteger("api_m1", bean::setM1)
-                    .setInteger("api_m2", bean::setM2);
+                    .setInteger("api_m2", bean::setM2)
+                    .reportUnknown();
 
             return bean;
         }

--- a/logbook/src/main/java/logbook/bean/MapTypes.java
+++ b/logbook/src/main/java/logbook/bean/MapTypes.java
@@ -44,9 +44,11 @@ public class MapTypes {
         public static Eventmap toEventmap(JsonObject json) {
             Eventmap bean = new Eventmap();
             JsonHelper.bind(json)
+                    .at("api_data.api_eventmap")
                     .setInteger("api_max_maphp", bean::setMaxMaphp)
                     .setInteger("api_now_maphp", bean::setNowMaphp)
-                    .setInteger("api_dmg", bean::setDmg);
+                    .setInteger("api_dmg", bean::setDmg)
+                    .reportUnknown();
             return bean;
         }
     }
@@ -75,8 +77,10 @@ public class MapTypes {
         public static Enemy toEnemy(JsonObject json) {
             Enemy bean = new Enemy();
             JsonHelper.bind(json)
+                    .at("api_data.api_enemy")
                     .setInteger("api_result", bean::setResult)
-                    .setString("api_result_str", bean::setResultStr);
+                    .setString("api_result_str", bean::setResultStr)
+                    .reportUnknown();
             return bean;
         }
     }
@@ -117,12 +121,14 @@ public class MapTypes {
         public static Happening toHappening(JsonObject json) {
             Happening bean = new Happening();
             JsonHelper.bind(json)
+                    .at("api_data.api_happening")
                     .setInteger("api_type", bean::setType)
                     .setInteger("api_count", bean::setCount)
                     .setInteger("api_usemst", bean::setUsemst)
                     .setInteger("api_mst_id", bean::setMstId)
                     .setInteger("api_icon_id", bean::setIconId)
-                    .setInteger("api_dentan", bean::setDentan);
+                    .setInteger("api_dentan", bean::setDentan)
+                    .reportUnknown();
             return bean;
         }
     }
@@ -160,11 +166,13 @@ public class MapTypes {
         public static Itemget toItemget(JsonObject json) {
             Itemget bean = new Itemget();
             JsonHelper.bind(json)
+                    .at("api_data.api_itemget[]")
                     .setInteger("api_getcount", bean::setGetcount)
                     .setInteger("api_icon_id", bean::setIconId)
                     .setInteger("api_id", bean::setId)
                     .setString("api_name", bean::setName)
-                    .setInteger("api_usemst", bean::setUsemst);
+                    .setInteger("api_usemst", bean::setUsemst)
+                    .reportUnknown();
             return bean;
         }
     }
@@ -190,7 +198,9 @@ public class MapTypes {
         public static SelectRoute toSelectRoute(JsonObject json) {
             SelectRoute bean = new SelectRoute();
             JsonHelper.bind(json)
-                    .setIntegerList("api_select_cells", bean::setSelectCells);
+                    .at("api_data.api_select_route")
+                    .setIntegerList("api_select_cells", bean::setSelectCells)
+                    .reportUnknown();
             return bean;
         }
     }

--- a/logbook/src/main/java/logbook/bean/Mapinfo.java
+++ b/logbook/src/main/java/logbook/bean/Mapinfo.java
@@ -61,11 +61,20 @@ public class Mapinfo implements Serializable {
         public static MapInfo toMapInfo(JsonValue json) {
             MapInfo bean = new MapInfo();
             JsonHelper.bind((JsonObject) json)
+                    .at("api_data.api_map_info[]")
                     .setInteger("api_id", bean::setId)
                     .setInteger("api_cleared", bean::setCleared)
                     .setInteger("api_exboss_flag", bean::setExbossFlag)
                     .setInteger("api_defeat_count", bean::setDefeatCount)
-                    .setInteger("api_air_base_decks", bean::setAirBaseDecks);
+                    .setInteger("api_air_base_decks", bean::setAirBaseDecks)
+                    .ignore(
+                            "api_gauge_num", // ゲージ番号
+                            "api_gauge_type", // ゲージ種別
+                            "api_required_defeat_count", // 必要撃破数
+                            "api_eventmap", // イベントマップ状態
+                            "api_sally_flag", // 出撃フラグ
+                            "api_s_no") // 海域内番号等
+                    .reportUnknown();
             return bean;
         }
     }
@@ -105,12 +114,14 @@ public class Mapinfo implements Serializable {
         public static AirBase toAirBase(JsonValue json) {
             AirBase bean = new AirBase();
             JsonHelper.bind((JsonObject) json)
+                    .at("api_data.api_air_base[]")
                     .setInteger("api_area_id", bean::setAreaId)
                     .setInteger("api_rid", bean::setRid)
                     .setString("api_name", bean::setName)
                     .set("api_distance", bean::setDistance, Distance::toDistance)
                     .setInteger("api_action_kind", bean::setActionKind)
-                    .set("api_plane_info", bean::setPlaneInfo, JsonHelper.toList(PlaneInfo::toPlaneInfo));
+                    .set("api_plane_info", bean::setPlaneInfo, JsonHelper.toList(PlaneInfo::toPlaneInfo))
+                    .reportUnknown();
             return bean;
         }
     }
@@ -138,8 +149,10 @@ public class Mapinfo implements Serializable {
         public static Distance toDistance(JsonValue json) {
             Distance bean = new Distance();
             JsonHelper.bind((JsonObject) json)
+                    .at("api_data.api_air_base[].api_distance")
                     .setInteger("api_base", bean::setBase)
-                    .setInteger("api_bonus", bean::setBonus);
+                    .setInteger("api_bonus", bean::setBonus)
+                    .reportUnknown();
             return bean;
         }
     }
@@ -179,12 +192,14 @@ public class Mapinfo implements Serializable {
         public static PlaneInfo toPlaneInfo(JsonValue json) {
             PlaneInfo bean = new PlaneInfo();
             JsonHelper.bind((JsonObject) json)
+                    .at("api_data.api_air_base[].api_plane_info[]")
                     .setInteger("api_squadron_id", bean::setSquadronId)
                     .setInteger("api_state", bean::setState)
                     .setInteger("api_slotid", bean::setSlotid)
                     .setInteger("api_count", bean::setCount)
                     .setInteger("api_max_count", bean::setMaxCount)
-                    .setInteger("api_cond", bean::setCond);
+                    .setInteger("api_cond", bean::setCond)
+                    .reportUnknown();
             return bean;
         }
     }

--- a/logbook/src/main/java/logbook/bean/Material.java
+++ b/logbook/src/main/java/logbook/bean/Material.java
@@ -31,8 +31,11 @@ public class Material implements Serializable {
     public static Material toMaterial(JsonObject json) {
         Material bean = new Material();
         JsonHelper.bind(json)
+                .at("api_data.api_material[]")
                 .setInteger("api_id", bean::setId)
-                .setInteger("api_value", bean::setValue);
+                .setInteger("api_value", bean::setValue)
+                .ignore("api_member_id") // 提督 ID
+                .reportUnknown();
         return bean;
     }
 }

--- a/logbook/src/main/java/logbook/bean/MissionResult.java
+++ b/logbook/src/main/java/logbook/bean/MissionResult.java
@@ -91,9 +91,11 @@ public class MissionResult implements Serializable {
         public static GetItem toGetItem(JsonObject json) {
             GetItem bean = new GetItem();
             JsonHelper.bind(json)
+                    .at("api_data.api_get_item")
                     .setInteger("api_useitem_id", bean::setUseitemId)
                     .setString("api_useitem_name", bean::setUseitemName)
-                    .setInteger("api_useitem_count", bean::setUseitemCount);
+                    .setInteger("api_useitem_count", bean::setUseitemCount)
+                    .reportUnknown();
             return bean;
         }
     }
@@ -107,6 +109,7 @@ public class MissionResult implements Serializable {
     public static MissionResult toMissionResult(JsonObject json) {
         MissionResult bean = new MissionResult();
         JsonHelper.bind(json)
+                .at("api_data")
                 .setInteger("api_clear_result", bean::setClearResult)
                 .setString("api_detail", bean::setDetail)
                 .setInteger("api_get_exp", bean::setGetExp)
@@ -127,7 +130,8 @@ public class MissionResult implements Serializable {
                 .setIntegerList("api_ship_id", bean::setShipId)
                 .setIntegerList("api_useitem_flag", bean::setUseitemFlag)
                 .set("api_get_item1", bean::setGetItem1, GetItem::toGetItem)
-                .set("api_get_item2", bean::setGetItem2, GetItem::toGetItem);
+                .set("api_get_item2", bean::setGetItem2, GetItem::toGetItem)
+                .reportUnknown();
         return bean;
     }
 }

--- a/logbook/src/main/java/logbook/bean/Ndock.java
+++ b/logbook/src/main/java/logbook/bean/Ndock.java
@@ -49,6 +49,7 @@ public class Ndock implements Serializable {
     public static Ndock toNdock(JsonObject json) {
         Ndock bean = new Ndock();
         JsonHelper.bind(json)
+                .at("api_data.api_ndock[]")
                 .setInteger("api_id", bean::setId)
                 .setLong("api_complete_time", bean::setCompleteTime)
                 .setInteger("api_item1", bean::setItem1)
@@ -56,7 +57,11 @@ public class Ndock implements Serializable {
                 .setInteger("api_item3", bean::setItem3)
                 .setInteger("api_item4", bean::setItem4)
                 .setInteger("api_ship_id", bean::setShipId)
-                .setInteger("api_state", bean::setState);
+                .setInteger("api_state", bean::setState)
+                .ignore(
+                        "api_member_id", // 提督 ID
+                        "api_complete_time_str") // 完了時刻の表示用文字列
+                .reportUnknown();
         return bean;
     }
 }

--- a/logbook/src/main/java/logbook/bean/QuestList.java
+++ b/logbook/src/main/java/logbook/bean/QuestList.java
@@ -83,6 +83,7 @@ public class QuestList implements Serializable {
             if (value instanceof JsonObject) {
                 Quest bean = new Quest();
                 JsonHelper.bind((JsonObject) value)
+                        .at("api_data.api_list[]")
                         .setInteger("api_no", bean::setNo)
                         .setInteger("api_category", bean::setCategory)
                         .setInteger("api_type", bean::setType)
@@ -92,7 +93,12 @@ public class QuestList implements Serializable {
                         .setIntegerList("api_get_material", bean::setGetMaterial)
                         .setInteger("api_bonus_flag", bean::setBonusFlag)
                         .setInteger("api_progress_flag", bean::setProgressFlag)
-                        .setInteger("api_invalid_flag", bean::setInvalidFlag);
+                        .setInteger("api_invalid_flag", bean::setInvalidFlag)
+                        .ignore(
+                                "api_voice_id", // ボイス
+                                "api_lost_badges", // 勲章消費？
+                                "api_select_rewards") // 選択報酬
+                        .reportUnknown();
                 return bean;
             } else {
                 return null;
@@ -109,12 +115,15 @@ public class QuestList implements Serializable {
     public static QuestList toQuestList(JsonObject json) {
         QuestList bean = new QuestList();
         JsonHelper.bind(json)
+                .at("api_data")
                 .setInteger("api_count", bean::setCount)
                 .setInteger("api_completed_kind", bean::setCompletedKind)
                 .setInteger("api_page_count", bean::setPageCount)
                 .setInteger("api_disp_page", bean::setDispPage)
                 .set("api_list", bean::setList, JsonHelper.toList(Quest::toQuest))
-                .setInteger("api_exec_count", bean::setExecCount);
+                .setInteger("api_exec_count", bean::setExecCount)
+                .ignore("api_exec_type") // 実行タイプ
+                .reportUnknown();
         return bean;
     }
 }

--- a/logbook/src/main/java/logbook/bean/Ship.java
+++ b/logbook/src/main/java/logbook/bean/Ship.java
@@ -191,6 +191,7 @@ public class Ship implements Chara, Serializable {
     public static Ship toShip(JsonObject json) {
         Ship bean = new Ship();
         JsonHelper.bind(json)
+                .at("api_data.api_ship[]")
                 .setInteger("api_id", bean::setId)
                 .setInteger("api_sortno", bean::setSortno)
                 .setInteger("api_ship_id", bean::setShipId)
@@ -223,7 +224,8 @@ public class Ship implements Chara, Serializable {
                 .setBoolean("api_locked", bean::setLocked)
                 .setBoolean("api_locked_equip", bean::setLockedEquip)
                 .set("api_sp_effect_items", bean::setSpEffectItems, JsonHelper.toList(SpEffectItem::toSpEffectItem))
-                .setInteger("api_sally_area", bean::setSallyArea);
+                .setInteger("api_sally_area", bean::setSallyArea)
+                .reportUnknown();
         return bean;
     }
 
@@ -257,11 +259,13 @@ public class Ship implements Chara, Serializable {
         public static SpEffectItem toSpEffectItem(JsonObject json) {
             SpEffectItem bean = new SpEffectItem();
             JsonHelper.bind(json)
-            .setInteger("api_kind", bean::setKind)
-            .setInteger("api_houg", bean::setHoug)
-            .setInteger("api_raig", bean::setRaig)
-            .setInteger("api_souk", bean::setSouk)
-            .setInteger("api_kaih", bean::setKaih);
+                    .at("api_data.api_ship[].api_sp_effect_items[]")
+                    .setInteger("api_kind", bean::setKind)
+                    .setInteger("api_houg", bean::setHoug)
+                    .setInteger("api_raig", bean::setRaig)
+                    .setInteger("api_souk", bean::setSouk)
+                    .setInteger("api_kaih", bean::setKaih)
+                    .reportUnknown();
             return bean;
         }
     }

--- a/logbook/src/main/java/logbook/bean/SlotItem.java
+++ b/logbook/src/main/java/logbook/bean/SlotItem.java
@@ -40,11 +40,13 @@ public class SlotItem implements Serializable {
     public static SlotItem toSlotItem(JsonObject json) {
         SlotItem bean = new SlotItem();
         JsonHelper.bind(json)
+                .at("api_data.api_slot_item[]")
                 .setInteger("api_id", bean::setId)
                 .setInteger("api_level", bean::setLevel)
                 .setInteger("api_alv", bean::setAlv)
                 .setBoolean("api_locked", bean::setLocked)
-                .setInteger("api_slotitem_id", bean::setSlotitemId);
+                .setInteger("api_slotitem_id", bean::setSlotitemId)
+                .reportUnknown();
         return bean;
     }
 }

--- a/logbook/src/main/java/logbook/bean/Useitem.java
+++ b/logbook/src/main/java/logbook/bean/Useitem.java
@@ -27,8 +27,10 @@ public class Useitem implements Serializable {
     public static Useitem toUseitem(JsonObject json) {
         Useitem bean = new Useitem();
         JsonHelper.bind(json)
+                .at("api_data.api_useitem[]")
                 .setInteger("api_id", bean::setId)
-                .setInteger("api_count", bean::setCount);
+                .setInteger("api_count", bean::setCount)
+                .reportUnknown();
         return bean;
     }
 }

--- a/logbook/src/main/java/logbook/internal/APIListener.java
+++ b/logbook/src/main/java/logbook/internal/APIListener.java
@@ -20,6 +20,7 @@ import logbook.Messages;
 import logbook.api.API;
 import logbook.api.APIListenerSpi;
 import logbook.internal.Tuple.Pair;
+import logbook.internal.api.ApiSchemaLog;
 import logbook.internal.proxy.ProxyContentListenerLogger;
 import logbook.plugin.PluginServices;
 import logbook.proxy.ContentListenerSpi;
@@ -135,7 +136,8 @@ public final class APIListener implements ContentListenerSpi {
         long startNanos = System.nanoTime();
         ProxyContentListenerLogger.Outcome outcome = ProxyContentListenerLogger.Outcome.SUCCESS;
         String errorDetail = null;
-        try {
+        try (ApiSchemaLog.Scope ignored = ApiSchemaLog.openRequest(
+                req.getRequestURI(), req.getRequestId(), handler.getClass().getName())) {
             log.atDebug()
                 .setMessage(() -> Messages.getString("APIListener.0", //$NON-NLS-1$
                         handler.getClass().getName(), req.getRequestURI()))


### PR DESCRIPTION
#### 変更内容
`ApiSchemaLog` による未定義キー検知を、`api_start2` 以外の母港・メンバー・日常系 API に対応した

#### 関連するIssue
Fixes #252

