### PR TITLE
未定義キーの検出を戦闘系に拡張

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -254,11 +254,15 @@ API レスポンス JSON のうち、bean / ハンドラが把握していない
 | リクエスト文脈 | 対応済み | `APIListener.createTask` が全ハンドラで `ApiSchemaLog.openRequest`（uri / requestId / handlerClass） |
 | `api_start2/getData` | 対応済み | `ApiStart2` の `api_data` KNOWN + 各マスタ bean の `at` / `ignore` / `reportUnknown` |
 | 母港・メンバー・日常系 | 対応済み（第1波） | 下記 bean / ハンドラ。`api_data` を選択読取する主要ハンドラは KNOWN 付き |
-| 戦闘系 | **未対応（第2波）** | `BattleTypes`・各戦闘 bean・戦闘結果。別 Issue で `at` / `reportUnknown` と ignore 整理 |
+| 戦闘系 | 対応済み（第2波） | `BattleTypes` ネスト・各 `IBattle` 具象・`BattleResult` に `at` / `reportUnknown` |
 
 **第1波の bean（`at` + `reportUnknown`）**: `Basic`, `Ship`, `SlotItem`, `Useitem`, `DeckPort`, `Material`, `Ndock`, `Kdock`, `MapStartNext`, `MissionResult`, `QuestList`, `Createitem`, `Mapinfo`, `MapTypes`（および既存の start2 マスタ bean）
 
 **第1波のハンドラ `api_data` KNOWN**: `ApiStart2`, `ApiPortPort`, `ApiGetMemberRequireInfo`, `ApiGetMemberShipDeck`, `ApiGetMemberShip3`, `ApiGetMemberMapinfo`
+
+**第2波の bean（`at` + `reportUnknown`）**: `BattleTypes`（Kouku / Stage* / Hougeki 等ネスト）、`SortieBattle` / `SortieAirbattle` / `SortieLdAirbattle` / `SortieLdShooting`、`BattleMidnightBattle` / `BattleMidnightSpMidnight`、連合系 `CombinedBattle*`、`BattleResult`（およびネスト）
+
+戦闘レスポンスは bean の `toBattle` / `toBattleResult` に集約されているため、ハンドラ側の `KNOWN` セットは原則不要。
 
 ### 有効化
 
@@ -304,7 +308,7 @@ API レスポンス JSON のうち、bean / ハンドラが把握していない
 3. ハンドラ直下のオブジェクトは `reportUnknownKeys` と `KNOWN`（対応済み ∪ 意図的未対応）を用意する
 4. キャプチャ突合でノイズになった既存キーは `ignore` / `IGNORED_API_DATA_KEYS` に移す（start2 と同じ手順）
 
-戦闘系への展開は第2波（別 Issue）。`api_max_slotplus` など実装が必要な未知キーは別途対応する。
+`api_max_slotplus` や `api_label_type` など実装が必要な未知キーは別途対応する。
 
 ## API レスポンス記録（開発者向け）
 

--- a/logbook/src/main/java/logbook/bean/BattleMidnightBattle.java
+++ b/logbook/src/main/java/logbook/bean/BattleMidnightBattle.java
@@ -80,6 +80,7 @@ public class BattleMidnightBattle implements IMidnightBattle {
     public static BattleMidnightBattle toBattle(JsonObject json) {
         BattleMidnightBattle bean = new BattleMidnightBattle();
         JsonHelper.bind(json)
+                .at("api_data")
                 .setInteger("api_dock_id", bean::setDockId)
                 .setInteger("api_deck_id", bean::setDockId)
                 .setIntegerList("api_ship_ke", bean::setShipKe)
@@ -98,7 +99,9 @@ public class BattleMidnightBattle implements IMidnightBattle {
                 .setInteger("api_smoke_type", bean::setSmokeType)
                 .setInteger("api_balloon_cell", bean::setBalloonCell)
                 .setInteger("api_atoll_cell", bean::setAtollCell)
-                .set("api_hougeki", bean::setHougeki, BattleTypes.MidnightHougeki::toMidnightHougeki);
+                .set("api_hougeki", bean::setHougeki, BattleTypes.MidnightHougeki::toMidnightHougeki)
+                .ignore("api_formation") // 昼戦レスポンスと同内容の再送。IMidnightBattle では未使用
+                .reportUnknown();
         return bean;
     }
 }

--- a/logbook/src/main/java/logbook/bean/BattleMidnightSpMidnight.java
+++ b/logbook/src/main/java/logbook/bean/BattleMidnightSpMidnight.java
@@ -91,6 +91,7 @@ public class BattleMidnightSpMidnight implements IMidnightBattle, IFormation, IN
     public static BattleMidnightSpMidnight toBattle(JsonObject json) {
         BattleMidnightSpMidnight bean = new BattleMidnightSpMidnight();
         JsonHelper.bind(json)
+                .at("api_data")
                 .setInteger("api_dock_id", bean::setDockId)
                 .setInteger("api_deck_id", bean::setDockId)
                 .setIntegerList("api_ship_ke", bean::setShipKe)
@@ -112,7 +113,8 @@ public class BattleMidnightSpMidnight implements IMidnightBattle, IFormation, IN
                 .setInteger("api_atoll_cell", bean::setAtollCell)
                 .set("api_hougeki", bean::setHougeki, BattleTypes.MidnightHougeki::toMidnightHougeki)
                 .setInteger("api_n_support_flag", bean::setNSupportFlag)
-                .set("api_n_support_info", bean::setNSupportInfo, BattleTypes.SupportInfo::toSupportInfo);
+                .set("api_n_support_info", bean::setNSupportInfo, BattleTypes.SupportInfo::toSupportInfo)
+                .reportUnknown();
         return bean;
     }
 }

--- a/logbook/src/main/java/logbook/bean/BattleResult.java
+++ b/logbook/src/main/java/logbook/bean/BattleResult.java
@@ -156,9 +156,11 @@ public class BattleResult implements Serializable {
         public static EnemyInfo toEnemyInfo(JsonObject json) {
             EnemyInfo bean = new EnemyInfo();
             JsonHelper.bind(json)
+                    .at("api_data.api_enemy_info")
                     .setString("api_level", bean::setLevel)
                     .setString("api_rank", bean::setRank)
-                    .setString("api_deck_name", bean::setDeckName);
+                    .setString("api_deck_name", bean::setDeckName)
+                    .reportUnknown();
             return bean;
         }
     }
@@ -192,10 +194,12 @@ public class BattleResult implements Serializable {
         public static GetShip toGetShip(JsonObject json) {
             GetShip bean = new GetShip();
             JsonHelper.bind(json)
+                    .at("api_data.api_get_ship")
                     .setInteger("api_ship_id", bean::setShipId)
                     .setString("api_ship_type", bean::setShipType)
                     .setString("api_ship_name", bean::setShipName)
-                    .setString("api_ship_getmes", bean::setShipGetmes);
+                    .setString("api_ship_getmes", bean::setShipGetmes)
+                    .reportUnknown();
             return bean;
         }
     }
@@ -226,9 +230,11 @@ public class BattleResult implements Serializable {
         public static GetEventitem toGetEventitem(JsonObject json) {
             GetEventitem bean = new GetEventitem();
             JsonHelper.bind(json)
+                    .at("api_data.api_get_eventitem[]")
                     .setInteger("api_type", bean::setType)
                     .setInteger("api_id", bean::setId)
-                    .setInteger("api_value", bean::setValue);
+                    .setInteger("api_value", bean::setValue)
+                    .reportUnknown();
             return bean;
         }
     }
@@ -256,8 +262,10 @@ public class BattleResult implements Serializable {
         public static Escape toEscape(JsonObject json) {
             Escape bean = new Escape();
             JsonHelper.bind(json)
+                    .at("api_data.api_escape")
                     .setIntegerList("api_escape_idx", bean::setEscapeIdx)
-                    .setIntegerList("api_tow_idx", bean::setTowIdx);
+                    .setIntegerList("api_tow_idx", bean::setTowIdx)
+                    .reportUnknown();
             return bean;
         }
     }
@@ -288,9 +296,11 @@ public class BattleResult implements Serializable {
         public static LandingHp toLandingHp(JsonObject json) {
             LandingHp bean = new LandingHp();
             JsonHelper.bind(json)
+                    .at("api_data.api_landing_hp")
                     .setInteger("api_now_hp", bean::setNowHp)
                     .setInteger("api_max_hp", bean::setMaxHp)
-                    .setInteger("api_sub_value", bean::setSubValue);
+                    .setInteger("api_sub_value", bean::setSubValue)
+                    .reportUnknown();
             return bean;
         }
     }
@@ -318,8 +328,10 @@ public class BattleResult implements Serializable {
         public static Useitem toUseitem(JsonObject json) {
             Useitem bean = new Useitem();
             JsonHelper.bind(json)
+                    .at("api_data.api_get_useitem")
                     .setInteger("api_useitem_id", bean::setUseitemId)
-                    .setString("api_useitem_name", bean::setUseitemName);
+                    .setString("api_useitem_name", bean::setUseitemName)
+                    .reportUnknown();
             return bean;
         }
     }
@@ -333,6 +345,7 @@ public class BattleResult implements Serializable {
     public static BattleResult toBattleResult(JsonObject json) {
         BattleResult bean = new BattleResult();
         JsonHelper.bind(json)
+                .at("api_data")
                 .setString("api_win_rank", bean::setWinRank)
                 .setInteger("api_get_exp", bean::setGetExp)
                 .setInteger("api_mvp", bean::setMvp)
@@ -362,7 +375,11 @@ public class BattleResult implements Serializable {
                 .setBoolean("api_escape_flag", bean::setEscapeFlag)
                 .set("api_escape", bean::setEscape, Escape::toEscape)
                 .set("api_landing_hp", bean::setLandingHp, LandingHp::toLandingHp)
-                .setInteger("api_m1", bean::setM1);
+                .setInteger("api_m1", bean::setM1)
+                .ignore(
+                        "api_ship_id", // 敵艦マスタ ID 一覧（昼戦 api_ship_ke と同系）
+                        "api_next_map_ids") // マップ開放演出
+                .reportUnknown();
         return bean;
     }
 }

--- a/logbook/src/main/java/logbook/bean/BattleTypes.java
+++ b/logbook/src/main/java/logbook/bean/BattleTypes.java
@@ -858,11 +858,13 @@ public class BattleTypes {
         public static Kouku toKouku(JsonObject json) {
             Kouku bean = new Kouku();
             JsonHelper.bind(json)
+                    .at("api_data.api_kouku")
                     .set("api_plane_from", bean::setPlaneFrom, JsonHelper.toList(JsonHelper::toIntegerList))
                     .set("api_stage1", bean::setStage1, Stage1::toStage1)
                     .set("api_stage2", bean::setStage2, Stage2::toStage2)
                     .set("api_stage3", bean::setStage3, Stage3::toStage3)
-                    .set("api_stage3_combined", bean::setStage3Combined, Stage3::toStage3);
+                    .set("api_stage3_combined", bean::setStage3Combined, Stage3::toStage3)
+                    .reportUnknown();
             return bean;
         }
     }
@@ -906,12 +908,14 @@ public class BattleTypes {
         public static Stage1 toStage1(JsonObject json) {
             Stage1 bean = new Stage1();
             JsonHelper.bind(json)
+                    .at("api_data.api_kouku.api_stage1")
                     .setInteger("api_f_count", bean::setFCount)
                     .setInteger("api_f_lostcount", bean::setFLostcount)
                     .setInteger("api_e_count", bean::setECount)
                     .setInteger("api_e_lostcount", bean::setELostcount)
                     .setInteger("api_disp_seiku", bean::setDispSeiku)
-                    .setIntegerList("api_touch_plane", bean::setTouchPlane);
+                    .setIntegerList("api_touch_plane", bean::setTouchPlane)
+                    .reportUnknown();
             return bean;
         }
     }
@@ -952,11 +956,13 @@ public class BattleTypes {
         public static Stage2 toStage2(JsonObject json) {
             Stage2 bean = new Stage2();
             JsonHelper.bind(json)
+                    .at("api_data.api_kouku.api_stage2")
                     .setInteger("api_f_count", bean::setFCount)
                     .setInteger("api_f_lostcount", bean::setFLostcount)
                     .setInteger("api_e_count", bean::setECount)
                     .setInteger("api_e_lostcount", bean::setELostcount)
-                    .set("api_air_fire", bean::setAirFire, AirFire::toAirFire);
+                    .set("api_air_fire", bean::setAirFire, AirFire::toAirFire)
+                    .reportUnknown();
             return bean;
         }
     }
@@ -987,9 +993,11 @@ public class BattleTypes {
         public static AirFire toAirFire(JsonObject json) {
             AirFire bean = new AirFire();
             JsonHelper.bind(json)
+                    .at("api_data.api_kouku.api_stage2.api_air_fire")
                     .setInteger("api_idx", bean::setIdx)
                     .setInteger("api_kind", bean::setKind)
-                    .setIntegerList("api_use_items", bean::setUseItems);
+                    .setIntegerList("api_use_items", bean::setUseItems)
+                    .reportUnknown();
             return bean;
         }
     }
@@ -1035,6 +1043,7 @@ public class BattleTypes {
         public static Stage3 toStage3(JsonObject json) {
             Stage3 bean = new Stage3();
             JsonHelper.bind(json)
+                    .at("api_data.api_kouku.api_stage3")
                     .setIntegerList("api_frai_flag", bean::setFraiFlag)
                     .setIntegerList("api_erai_flag", bean::setEraiFlag)
                     .setIntegerList("api_fbak_flag", bean::setFbakFlag)
@@ -1042,7 +1051,11 @@ public class BattleTypes {
                     .setIntegerList("api_fcl_flag", bean::setFclFlag)
                     .setIntegerList("api_ecl_flag", bean::setEclFlag)
                     .setDoubleList("api_fdam", bean::setFdam)
-                    .setDoubleList("api_edam", bean::setEdam);
+                    .setDoubleList("api_edam", bean::setEdam)
+                    .ignore(
+                            "api_f_sp_list", // 艦並列の航空特殊フラグ（概ね null/[1]。HPは fdam）
+                            "api_e_sp_list") // 同上（敵側。本観測では常に null）
+                    .reportUnknown();
             return bean;
         }
     }
@@ -1070,8 +1083,10 @@ public class BattleTypes {
         public static SupportInfo toSupportInfo(JsonObject json) {
             SupportInfo bean = new SupportInfo();
             JsonHelper.bind(json)
+                    .at("api_data.api_support_info")
                     .set("api_support_airatack", bean::setSupportAiratack, SupportAiratack::toSupportAiratack)
-                    .set("api_support_hourai", bean::setSupportHourai, SupportHourai::toSupportHourai);
+                    .set("api_support_hourai", bean::setSupportHourai, SupportHourai::toSupportHourai)
+                    .reportUnknown();
             return bean;
         }
     }
@@ -1117,6 +1132,7 @@ public class BattleTypes {
         public static SupportAiratack toSupportAiratack(JsonObject json) {
             SupportAiratack bean = new SupportAiratack();
             JsonHelper.bind(json)
+                    .at("api_data.api_support_info.api_support_airatack")
                     .setInteger("api_deck_id", bean::setDeckId)
                     .setIntegerList("api_ship_id", bean::setShipId)
                     .setIntegerList("api_undressing_flag", bean::setUndressingFlag)
@@ -1124,7 +1140,8 @@ public class BattleTypes {
                     .set("api_plane_from", bean::setPlaneFrom, JsonHelper.toList(JsonHelper::toIntegerList))
                     .set("api_stage1", bean::setStage1, Stage1::toStage1)
                     .set("api_stage2", bean::setStage2, Stage2::toStage2)
-                    .set("api_stage3", bean::setStage3, Stage3::toStage3);
+                    .set("api_stage3", bean::setStage3, Stage3::toStage3)
+                    .reportUnknown();
             return bean;
         }
     }
@@ -1161,11 +1178,13 @@ public class BattleTypes {
         public static SupportHourai toSupportHourai(JsonObject json) {
             SupportHourai bean = new SupportHourai();
             JsonHelper.bind(json)
+                    .at("api_data.api_support_info.api_support_hourai")
                     .setInteger("api_deck_id", bean::setDeckId)
                     .setIntegerList("api_ship_id", bean::setShipId)
                     .setIntegerList("api_undressing_flag", bean::setUndressingFlag)
                     .setIntegerList("api_cl_list", bean::setClList)
-                    .setDoubleList("api_damage", bean::setDamage);
+                    .setDoubleList("api_damage", bean::setDamage)
+                    .reportUnknown();
             return bean;
         }
     }
@@ -1211,6 +1230,7 @@ public class BattleTypes {
         public static OpeningRaigeki toOpeningRaigeki(JsonObject json) {
             OpeningRaigeki bean = new OpeningRaigeki();
             JsonHelper.bind(json)
+                    .at("api_data.api_opening_atack")
                     .set("api_frai_list_items", bean::setFrai,JsonHelper.toList(JsonHelper::toIntegerList))
                     .set("api_erai_list_items", bean::setErai,JsonHelper.toList(JsonHelper::toIntegerList))
                     .setDoubleList("api_fdam", bean::setFdam)
@@ -1218,7 +1238,8 @@ public class BattleTypes {
                     .set("api_fydam_list_items", bean::setFydam,JsonHelper.toList(JsonHelper::toDoubleList))
                     .set("api_eydam_list_items", bean::setEydam,JsonHelper.toList(JsonHelper::toDoubleList))
                     .set("api_fcl_list_items", bean::setFcl,JsonHelper.toList(JsonHelper::toIntegerList))
-                    .set("api_ecl_list_items", bean::setEcl,JsonHelper.toList(JsonHelper::toIntegerList));
+                    .set("api_ecl_list_items", bean::setEcl,JsonHelper.toList(JsonHelper::toIntegerList))
+                    .reportUnknown();
             return bean;
         }
     }
@@ -1264,6 +1285,7 @@ public class BattleTypes {
         public static Raigeki toRaigeki(JsonObject json) {
             Raigeki bean = new Raigeki();
             JsonHelper.bind(json)
+                    .at("api_data.api_raigeki")
                     .setIntegerList("api_frai", bean::setFrai)
                     .setIntegerList("api_erai", bean::setErai)
                     .setDoubleList("api_fdam", bean::setFdam)
@@ -1271,7 +1293,8 @@ public class BattleTypes {
                     .setDoubleList("api_fydam", bean::setFydam)
                     .setDoubleList("api_eydam", bean::setEydam)
                     .setIntegerList("api_fcl", bean::setFcl)
-                    .setIntegerList("api_ecl", bean::setEcl);
+                    .setIntegerList("api_ecl", bean::setEcl)
+                    .reportUnknown();
             return bean;
         }
     }
@@ -1314,13 +1337,15 @@ public class BattleTypes {
         public static Hougeki toHougeki(JsonObject json) {
             Hougeki bean = new Hougeki();
             JsonHelper.bind(json)
+                    .at("api_data.api_hougeki1")
                     .setIntegerList("api_at_list", bean::setAtList)
                     .setIntegerList("api_at_type", bean::setAtType)
                     .set("api_df_list", bean::setDfList, JsonHelper.toList(JsonHelper::checkedToIntegerList))
                     .set("api_si_list", bean::setSiList, JsonHelper.toList(JsonHelper::checkedToIntegerList))
                     .set("api_cl_list", bean::setClList, JsonHelper.toList(JsonHelper::checkedToIntegerList))
                     .set("api_damage", bean::setDamage, JsonHelper.toList(JsonHelper::checkedToDoubleList))
-                    .setIntegerList("api_at_eflag", bean::setAtEflag);
+                    .setIntegerList("api_at_eflag", bean::setAtEflag)
+                    .reportUnknown();
             return bean;
         }
     }
@@ -1370,6 +1395,7 @@ public class BattleTypes {
         public static MidnightHougeki toMidnightHougeki(JsonObject json) {
             MidnightHougeki bean = new MidnightHougeki();
             JsonHelper.bind(json)
+                    .at("api_data.api_hougeki")
                     .setIntegerList("api_at_list", bean::setAtList)
                     .setIntegerList("api_at_type", bean::setAtType)
                     .setIntegerList("api_n_mother_list", bean::setNMotherList)
@@ -1378,7 +1404,8 @@ public class BattleTypes {
                     .set("api_cl_list", bean::setClList, JsonHelper.toList(JsonHelper::checkedToIntegerList))
                     .setIntegerList("api_sp_list", bean::setSpList)
                     .set("api_damage", bean::setDamage, JsonHelper.toList(JsonHelper::checkedToDoubleList))
-                    .setIntegerList("api_at_eflag", bean::setAtEflag);
+                    .setIntegerList("api_at_eflag", bean::setAtEflag)
+                    .reportUnknown();
             return bean;
         }
     }
@@ -1424,6 +1451,7 @@ public class BattleTypes {
         public static AirBaseAttack toAirBaseAttack(JsonObject json) {
             AirBaseAttack bean = new AirBaseAttack();
             JsonHelper.bind(json)
+                    .at("api_data.api_air_base_attack[]")
                     .setInteger("api_base_id", bean::setBaseId)
                     .set("api_plane_from", bean::setPlaneFrom, JsonHelper.toList(JsonHelper::toIntegerList))
                     .set("api_squadron_plane", bean::setSquadronPlane,
@@ -1434,7 +1462,8 @@ public class BattleTypes {
                     .set("api_stage2", bean::setStage2, Stage2::toStage2)
                     .set("api_stage3", bean::setStage3, Stage3::toStage3)
                     .set("api_stage3_combined", bean::setStage3Combined, Stage3::toStage3)
-                    .setIntegerList("api_stage_flag", bean::setStageFlag);
+                    .setIntegerList("api_stage_flag", bean::setStageFlag)
+                    .reportUnknown();
             return bean;
         }
     }
@@ -1462,8 +1491,10 @@ public class BattleTypes {
         public static SquadronPlane toSquadronPlane(JsonObject json) {
             SquadronPlane bean = new SquadronPlane();
             JsonHelper.bind(json)
+                    .at("api_data.api_air_base_attack[].api_squadron_plane[]")
                     .setInteger("api_count", bean::setCount)
-                    .setInteger("api_mst_id", bean::setMstId);
+                    .setInteger("api_mst_id", bean::setMstId)
+                    .reportUnknown();
             return bean;
         }
     }
@@ -1506,13 +1537,15 @@ public class BattleTypes {
         public static FriendlyInfo toFriendlyInfo(JsonObject json) {
             FriendlyInfo bean = new FriendlyInfo();
             JsonHelper.bind(json)
+                    .at("api_data.api_friendly_info")
                     .setInteger("api_production_type", bean::setProductionType)
                     .setIntegerList("api_ship_id", bean::setShipId)
                     .setIntegerList("api_ship_lv", bean::setShipLv)
                     .setIntegerList("api_nowhps", bean::setNowhps)
                     .setIntegerList("api_maxhps", bean::setMaxhps)
                     .set("api_Slot", bean::setSlot, JsonHelper.toList(JsonHelper::toIntegerList))
-                    .set("api_Param", bean::setParam, JsonHelper.toList(JsonHelper::toIntegerList));
+                    .set("api_Param", bean::setParam, JsonHelper.toList(JsonHelper::toIntegerList))
+                    .reportUnknown();
             return bean;
         }
     }
@@ -1540,8 +1573,10 @@ public class BattleTypes {
         public static FriendlyBattle toFriendlyBattle(JsonObject json) {
             FriendlyBattle bean = new FriendlyBattle();
             JsonHelper.bind(json)
+                    .at("api_data.api_friendly_battle")
                     .setIntegerList("api_flare_pos", bean::setFlarePos)
-                    .set("api_hougeki", bean::setHougeki, BattleTypes.MidnightHougeki::toMidnightHougeki);
+                    .set("api_hougeki", bean::setHougeki, BattleTypes.MidnightHougeki::toMidnightHougeki)
+                    .reportUnknown();
             return bean;
         }
     }

--- a/logbook/src/main/java/logbook/bean/CombinedBattleAirbattle.java
+++ b/logbook/src/main/java/logbook/bean/CombinedBattleAirbattle.java
@@ -116,6 +116,7 @@ public class CombinedBattleAirbattle
     public static CombinedBattleAirbattle toBattle(JsonObject json) {
         CombinedBattleAirbattle bean = new CombinedBattleAirbattle();
         JsonHelper.bind(json)
+                .at("api_data")
                 .set("api_air_base_injection", bean::setAirBaseInjection,
                         BattleTypes.AirBaseAttack::toAirBaseAttack)
                 .set("api_air_base_attack", bean::setAirBaseAttack,
@@ -146,7 +147,8 @@ public class CombinedBattleAirbattle
                 .setInteger("api_support_flag", bean::setSupportFlag)
                 .set("api_support_info", bean::setSupportInfo, BattleTypes.SupportInfo::toSupportInfo)
                 .setIntegerList("api_stage_flag2", bean::setStageFlag2)
-                .set("api_kouku2", bean::setKouku2, BattleTypes.Kouku::toKouku);
+                .set("api_kouku2", bean::setKouku2, BattleTypes.Kouku::toKouku)
+                .reportUnknown();
         return bean;
     }
 }

--- a/logbook/src/main/java/logbook/bean/CombinedBattleBattle.java
+++ b/logbook/src/main/java/logbook/bean/CombinedBattleBattle.java
@@ -137,6 +137,7 @@ public class CombinedBattleBattle implements ICombinedBattle, ISortieHougeki, IF
     public static CombinedBattleBattle toBattle(JsonObject json) {
         CombinedBattleBattle bean = new CombinedBattleBattle();
         JsonHelper.bind(json)
+                .at("api_data")
                 .set("api_air_base_injection", bean::setAirBaseInjection,
                         BattleTypes.AirBaseAttack::toAirBaseAttack)
                 .set("api_air_base_attack", bean::setAirBaseAttack,
@@ -174,7 +175,8 @@ public class CombinedBattleBattle implements ICombinedBattle, ISortieHougeki, IF
                 .set("api_hougeki1", bean::setHougeki1, BattleTypes.Hougeki::toHougeki)
                 .set("api_raigeki", bean::setRaigeki, BattleTypes.Raigeki::toRaigeki)
                 .set("api_hougeki2", bean::setHougeki2, BattleTypes.Hougeki::toHougeki)
-                .set("api_hougeki3", bean::setHougeki3, BattleTypes.Hougeki::toHougeki);
+                .set("api_hougeki3", bean::setHougeki3, BattleTypes.Hougeki::toHougeki)
+                .reportUnknown();
         return bean;
     }
 }

--- a/logbook/src/main/java/logbook/bean/CombinedBattleBattleWater.java
+++ b/logbook/src/main/java/logbook/bean/CombinedBattleBattleWater.java
@@ -137,6 +137,7 @@ public class CombinedBattleBattleWater implements ICombinedBattle,  ISortieHouge
     public static CombinedBattleBattleWater toBattle(JsonObject json) {
         CombinedBattleBattleWater bean = new CombinedBattleBattleWater();
         JsonHelper.bind(json)
+                .at("api_data")
                 .set("api_air_base_injection", bean::setAirBaseInjection,
                         BattleTypes.AirBaseAttack::toAirBaseAttack)
                 .set("api_air_base_attack", bean::setAirBaseAttack,
@@ -174,7 +175,8 @@ public class CombinedBattleBattleWater implements ICombinedBattle,  ISortieHouge
                 .set("api_hougeki1", bean::setHougeki1, BattleTypes.Hougeki::toHougeki)
                 .set("api_hougeki2", bean::setHougeki2, BattleTypes.Hougeki::toHougeki)
                 .set("api_hougeki3", bean::setHougeki3, BattleTypes.Hougeki::toHougeki)
-                .set("api_raigeki", bean::setRaigeki, BattleTypes.Raigeki::toRaigeki);
+                .set("api_raigeki", bean::setRaigeki, BattleTypes.Raigeki::toRaigeki)
+                .reportUnknown();
         return bean;
     }
 }

--- a/logbook/src/main/java/logbook/bean/CombinedBattleEachBattle.java
+++ b/logbook/src/main/java/logbook/bean/CombinedBattleEachBattle.java
@@ -156,6 +156,7 @@ public class CombinedBattleEachBattle implements ICombinedBattle, ICombinedEcBat
     public static CombinedBattleEachBattle toBattle(JsonObject json) {
         CombinedBattleEachBattle bean = new CombinedBattleEachBattle();
         JsonHelper.bind(json)
+                .at("api_data")
                 .set("api_air_base_injection", bean::setAirBaseInjection,
                         BattleTypes.AirBaseAttack::toAirBaseAttack)
                 .set("api_air_base_attack", bean::setAirBaseAttack,
@@ -199,7 +200,8 @@ public class CombinedBattleEachBattle implements ICombinedBattle, ICombinedEcBat
                 .set("api_hougeki1", bean::setHougeki1, BattleTypes.Hougeki::toHougeki)
                 .set("api_raigeki", bean::setRaigeki, BattleTypes.Raigeki::toRaigeki)
                 .set("api_hougeki2", bean::setHougeki2, BattleTypes.Hougeki::toHougeki)
-                .set("api_hougeki3", bean::setHougeki3, BattleTypes.Hougeki::toHougeki);
+                .set("api_hougeki3", bean::setHougeki3, BattleTypes.Hougeki::toHougeki)
+                .reportUnknown();
         return bean;
     }
 }

--- a/logbook/src/main/java/logbook/bean/CombinedBattleEcBattle.java
+++ b/logbook/src/main/java/logbook/bean/CombinedBattleEcBattle.java
@@ -149,6 +149,7 @@ public class CombinedBattleEcBattle implements ICombinedEcBattle, ISortieHougeki
     public static CombinedBattleEcBattle toBattle(JsonObject json) {
         CombinedBattleEcBattle bean = new CombinedBattleEcBattle();
         JsonHelper.bind(json)
+                .at("api_data")
                 .set("api_air_base_injection", bean::setAirBaseInjection,
                         BattleTypes.AirBaseAttack::toAirBaseAttack)
                 .set("api_air_base_attack", bean::setAirBaseAttack,
@@ -190,7 +191,9 @@ public class CombinedBattleEcBattle implements ICombinedEcBattle, ISortieHougeki
                 .set("api_hougeki1", bean::setHougeki1, BattleTypes.Hougeki::toHougeki)
                 .set("api_hougeki2", bean::setHougeki2, BattleTypes.Hougeki::toHougeki)
                 .set("api_hougeki3", bean::setHougeki3, BattleTypes.Hougeki::toHougeki)
-                .set("api_raigeki", bean::setRaigeki, BattleTypes.Raigeki::toRaigeki);
+                .set("api_raigeki", bean::setRaigeki, BattleTypes.Raigeki::toRaigeki)
+                .ignore("api_flavor_info") // ボス台詞・ボイス演出
+                .reportUnknown();
         return bean;
     }
 }

--- a/logbook/src/main/java/logbook/bean/CombinedBattleEcMidnightBattle.java
+++ b/logbook/src/main/java/logbook/bean/CombinedBattleEcMidnightBattle.java
@@ -90,6 +90,15 @@ public class CombinedBattleEcMidnightBattle implements ICombinedBattle, ICombine
     /** api_flare_pos */
     private List<Integer> flarePos;
 
+    /** api_smoke_type */
+    private Integer smokeType;
+
+    /** api_balloon_cell */
+    private Integer balloonCell;
+
+    /** api_atoll_cell */
+    private Integer atollCell;
+
     /** api_hougeki */
     private BattleTypes.MidnightHougeki hougeki;
 
@@ -102,6 +111,7 @@ public class CombinedBattleEcMidnightBattle implements ICombinedBattle, ICombine
     public static CombinedBattleEcMidnightBattle toBattle(JsonObject json) {
         CombinedBattleEcMidnightBattle bean = new CombinedBattleEcMidnightBattle();
         JsonHelper.bind(json)
+                .at("api_data")
                 .setIntegerList("api_active_deck", bean::setActiveDeck)
                 .setInteger("api_dock_id", bean::setDockId)
                 .setInteger("api_deck_id", bean::setDockId)
@@ -127,7 +137,12 @@ public class CombinedBattleEcMidnightBattle implements ICombinedBattle, ICombine
                 .set("api_friendly_battle", bean::setFriendlyBattle, BattleTypes.FriendlyBattle::toFriendlyBattle)
                 .setIntegerList("api_touch_plane", bean::setTouchPlane)
                 .setIntegerList("api_flare_pos", bean::setFlarePos)
-                .set("api_hougeki", bean::setHougeki, BattleTypes.MidnightHougeki::toMidnightHougeki);
+                .setInteger("api_smoke_type", bean::setSmokeType)
+                .setInteger("api_balloon_cell", bean::setBalloonCell)
+                .setInteger("api_atoll_cell", bean::setAtollCell)
+                .set("api_hougeki", bean::setHougeki, BattleTypes.MidnightHougeki::toMidnightHougeki)
+                .ignore("api_formation") // 昼戦と同内容の再送。IMidnightBattle では未使用
+                .reportUnknown();
         return bean;
     }
 }

--- a/logbook/src/main/java/logbook/bean/CombinedBattleEcNightToDay.java
+++ b/logbook/src/main/java/logbook/bean/CombinedBattleEcNightToDay.java
@@ -170,6 +170,7 @@ public class CombinedBattleEcNightToDay implements ICombinedBattle, ICombinedEcB
     public static CombinedBattleEcNightToDay toBattle(JsonObject json) {
         CombinedBattleEcNightToDay bean = new CombinedBattleEcNightToDay();
         JsonHelper.bind(json)
+                .at("api_data")
                 .setInteger("api_deck_id", bean::setDockId)
                 .setIntegerList("api_formation", bean::setFormation)
                 .setIntegerList("api_f_nowhps", bean::setFNowhps)
@@ -215,7 +216,8 @@ public class CombinedBattleEcNightToDay implements ICombinedBattle, ICombinedEcB
                 .set("api_hougeki1", bean::setHougeki1, BattleTypes.Hougeki::toHougeki)
                 .set("api_hougeki2", bean::setHougeki2, BattleTypes.Hougeki::toHougeki)
                 .set("api_hougeki3", bean::setHougeki3, BattleTypes.Hougeki::toHougeki)
-                .set("api_raigeki", bean::setRaigeki, BattleTypes.Raigeki::toRaigeki);
+                .set("api_raigeki", bean::setRaigeki, BattleTypes.Raigeki::toRaigeki)
+                .reportUnknown();
         return bean;
     }
 }

--- a/logbook/src/main/java/logbook/bean/CombinedBattleLdAirbattle.java
+++ b/logbook/src/main/java/logbook/bean/CombinedBattleLdAirbattle.java
@@ -104,6 +104,7 @@ public class CombinedBattleLdAirbattle
     public static CombinedBattleLdAirbattle toBattle(JsonObject json) {
         CombinedBattleLdAirbattle bean = new CombinedBattleLdAirbattle();
         JsonHelper.bind(json)
+                .at("api_data")
                 .set("api_air_base_injection", bean::setAirBaseInjection,
                         BattleTypes.AirBaseAttack::toAirBaseAttack)
                 .set("api_air_base_attack", bean::setAirBaseAttack,
@@ -130,7 +131,8 @@ public class CombinedBattleLdAirbattle
                 .setIntegerList("api_formation", bean::setFormation)
                 .setIntegerList("api_stage_flag", bean::setStageFlag)
                 .set("api_injection_kouku", bean::setInjectionKouku, BattleTypes.Kouku::toKouku)
-                .set("api_kouku", bean::setKouku, BattleTypes.Kouku::toKouku);
+                .set("api_kouku", bean::setKouku, BattleTypes.Kouku::toKouku)
+                .reportUnknown();
         return bean;
     }
 }

--- a/logbook/src/main/java/logbook/bean/CombinedBattleMidnightBattle.java
+++ b/logbook/src/main/java/logbook/bean/CombinedBattleMidnightBattle.java
@@ -81,6 +81,7 @@ public class CombinedBattleMidnightBattle implements ICombinedBattle, IMidnightB
     public static CombinedBattleMidnightBattle toBattle(JsonObject json) {
         CombinedBattleMidnightBattle bean = new CombinedBattleMidnightBattle();
         JsonHelper.bind(json)
+                .at("api_data")
                 .setInteger("api_dock_id", bean::setDockId)
                 .setInteger("api_deck_id", bean::setDockId)
                 .setIntegerList("api_ship_ke", bean::setShipKe)
@@ -99,7 +100,8 @@ public class CombinedBattleMidnightBattle implements ICombinedBattle, IMidnightB
                 .set("api_friendly_battle", bean::setFriendlyBattle, BattleTypes.FriendlyBattle::toFriendlyBattle)
                 .setIntegerList("api_touch_plane", bean::setTouchPlane)
                 .setIntegerList("api_flare_pos", bean::setFlarePos)
-                .set("api_hougeki", bean::setHougeki, BattleTypes.MidnightHougeki::toMidnightHougeki);
+                .set("api_hougeki", bean::setHougeki, BattleTypes.MidnightHougeki::toMidnightHougeki)
+                .reportUnknown();
         return bean;
     }
 }

--- a/logbook/src/main/java/logbook/bean/CombinedBattleSpMidnight.java
+++ b/logbook/src/main/java/logbook/bean/CombinedBattleSpMidnight.java
@@ -92,6 +92,7 @@ public class CombinedBattleSpMidnight implements ICombinedBattle, IMidnightBattl
     public static CombinedBattleSpMidnight toBattle(JsonObject json) {
         CombinedBattleSpMidnight bean = new CombinedBattleSpMidnight();
         JsonHelper.bind(json)
+                .at("api_data")
                 .setInteger("api_dock_id", bean::setDockId)
                 .setInteger("api_deck_id", bean::setDockId)
                 .setIntegerList("api_ship_ke", bean::setShipKe)
@@ -113,7 +114,8 @@ public class CombinedBattleSpMidnight implements ICombinedBattle, IMidnightBattl
                 .setIntegerList("api_flare_pos", bean::setFlarePos)
                 .set("api_hougeki", bean::setHougeki, BattleTypes.MidnightHougeki::toMidnightHougeki)
                 .setInteger("api_n_support_flag", bean::setNSupportFlag)
-                .set("api_n_support_info", bean::setNSupportInfo, BattleTypes.SupportInfo::toSupportInfo);
+                .set("api_n_support_info", bean::setNSupportInfo, BattleTypes.SupportInfo::toSupportInfo)
+                .reportUnknown();
         return bean;
     }
 }

--- a/logbook/src/main/java/logbook/bean/SortieAirbattle.java
+++ b/logbook/src/main/java/logbook/bean/SortieAirbattle.java
@@ -105,6 +105,7 @@ public class SortieAirbattle implements ISortieBattle, IFormation, IAirbattle, I
     public static SortieAirbattle toAirbattle(JsonObject json) {
         SortieAirbattle bean = new SortieAirbattle();
         JsonHelper.bind(json)
+                .at("api_data")
                 .set("api_air_base_injection", bean::setAirBaseInjection,
                         BattleTypes.AirBaseAttack::toAirBaseAttack)
                 .set("api_air_base_attack", bean::setAirBaseAttack,
@@ -132,7 +133,8 @@ public class SortieAirbattle implements ISortieBattle, IFormation, IAirbattle, I
                 .setInteger("api_support_flag", bean::setSupportFlag)
                 .set("api_support_info", bean::setSupportInfo, BattleTypes.SupportInfo::toSupportInfo)
                 .setIntegerList("api_stage_flag2", bean::setStageFlag2)
-                .set("api_kouku2", bean::setKouku2, BattleTypes.Kouku::toKouku);
+                .set("api_kouku2", bean::setKouku2, BattleTypes.Kouku::toKouku)
+                .reportUnknown();
         return bean;
     }
 }

--- a/logbook/src/main/java/logbook/bean/SortieBattle.java
+++ b/logbook/src/main/java/logbook/bean/SortieBattle.java
@@ -127,6 +127,7 @@ public class SortieBattle
     public static SortieBattle toBattle(JsonObject json) {
         SortieBattle bean = new SortieBattle();
         JsonHelper.bind(json)
+                .at("api_data")
                 .set("api_air_base_injection", bean::setAirBaseInjection,
                         BattleTypes.AirBaseAttack::toAirBaseAttack)
                 .set("api_air_base_attack", bean::setAirBaseAttack,
@@ -161,7 +162,9 @@ public class SortieBattle
                 .set("api_hougeki1", bean::setHougeki1, BattleTypes.Hougeki::toHougeki)
                 .set("api_raigeki", bean::setRaigeki, BattleTypes.Raigeki::toRaigeki)
                 .set("api_hougeki2", bean::setHougeki2, BattleTypes.Hougeki::toHougeki)
-                .set("api_hougeki3", bean::setHougeki3, BattleTypes.Hougeki::toHougeki);
+                .set("api_hougeki3", bean::setHougeki3, BattleTypes.Hougeki::toHougeki)
+                .ignore("api_flavor_info") // ボス台詞・ボイス演出
+                .reportUnknown();
         return bean;
     }
 }

--- a/logbook/src/main/java/logbook/bean/SortieLdAirbattle.java
+++ b/logbook/src/main/java/logbook/bean/SortieLdAirbattle.java
@@ -94,6 +94,7 @@ public class SortieLdAirbattle
     public static SortieLdAirbattle toBattle(JsonObject json) {
         SortieLdAirbattle bean = new SortieLdAirbattle();
         JsonHelper.bind(json)
+                .at("api_data")
                 .set("api_air_base_injection", bean::setAirBaseInjection,
                         BattleTypes.AirBaseAttack::toAirBaseAttack)
                 .set("api_air_base_attack", bean::setAirBaseAttack,
@@ -117,7 +118,8 @@ public class SortieLdAirbattle
                 .setIntegerList("api_formation", bean::setFormation)
                 .setIntegerList("api_stage_flag", bean::setStageFlag)
                 .set("api_injection_kouku", bean::setInjectionKouku, BattleTypes.Kouku::toKouku)
-                .set("api_kouku", bean::setKouku, BattleTypes.Kouku::toKouku);
+                .set("api_kouku", bean::setKouku, BattleTypes.Kouku::toKouku)
+                .reportUnknown();
         return bean;
     }
 }

--- a/logbook/src/main/java/logbook/bean/SortieLdShooting.java
+++ b/logbook/src/main/java/logbook/bean/SortieLdShooting.java
@@ -128,6 +128,7 @@ public class SortieLdShooting
     public static SortieLdShooting toBattle(JsonObject json) {
         SortieLdShooting bean = new SortieLdShooting();
         JsonHelper.bind(json)
+                .at("api_data")
                 .set("api_air_base_injection", bean::setAirBaseInjection,
                         BattleTypes.AirBaseAttack::toAirBaseAttack)
                 .set("api_air_base_attack", bean::setAirBaseAttack,
@@ -162,7 +163,8 @@ public class SortieLdShooting
                 .set("api_hougeki1", bean::setHougeki1, BattleTypes.Hougeki::toHougeki)
                 .set("api_raigeki", bean::setRaigeki, BattleTypes.Raigeki::toRaigeki)
                 .set("api_hougeki2", bean::setHougeki2, BattleTypes.Hougeki::toHougeki)
-                .set("api_hougeki3", bean::setHougeki3, BattleTypes.Hougeki::toHougeki);
+                .set("api_hougeki3", bean::setHougeki3, BattleTypes.Hougeki::toHougeki)
+                .reportUnknown();
         return bean;
     }
 }


### PR DESCRIPTION
#### 変更内容
#247で対応した `ApiSchemaLog` による未定義キー検知を、戦闘系 API に対応

#### 関連するIssue
Fixes #254