### PR TITLE
api_user_nameは対象外とする

### DIFF
--- a/logbook/src/main/java/logbook/bean/BattleResult.java
+++ b/logbook/src/main/java/logbook/bean/BattleResult.java
@@ -160,6 +160,7 @@ public class BattleResult implements Serializable {
                     .setString("api_level", bean::setLevel)
                     .setString("api_rank", bean::setRank)
                     .setString("api_deck_name", bean::setDeckName)
+                    .ignore("api_user_name") // 演習のみ
                     .reportUnknown();
             return bean;
         }


### PR DESCRIPTION
#### 変更内容
`BattleResult` の `api_enemy_info.api_user_name` は演習のみに出現。空なので対象外とする

#### 関連するIssue
Fixes #258

