### PR TITLE
「現在の演習」の相手艦バナーに青リボン／白タスキの描画追加

### DIFF
--- a/logbook/src/main/java/logbook/bean/BattleMidnightBattle.java
+++ b/logbook/src/main/java/logbook/bean/BattleMidnightBattle.java
@@ -47,6 +47,9 @@ public class BattleMidnightBattle implements IMidnightBattle {
     /** api_eParam */
     private List<List<Integer>> eParam;
 
+    /** api_e_effect_list（演習相手艦のリボン種別・表示用） */
+    private List<List<Integer>> eEffectList;
+
     /** api_friendly_info */
     private BattleTypes.FriendlyInfo friendlyInfo;
 
@@ -92,6 +95,7 @@ public class BattleMidnightBattle implements IMidnightBattle {
                 .set("api_eSlot", bean::setESlot, JsonHelper.toList(JsonHelper::toIntegerList))
                 .set("api_fParam", bean::setFParam, JsonHelper.toList(JsonHelper::toIntegerList))
                 .set("api_eParam", bean::setEParam, JsonHelper.toList(JsonHelper::toIntegerList))
+                .set("api_e_effect_list", bean::setEEffectList, JsonHelper.toList(JsonHelper::toIntegerList))
                 .set("api_friendly_info", bean::setFriendlyInfo, BattleTypes.FriendlyInfo::toFriendlyInfo)
                 .set("api_friendly_battle", bean::setFriendlyBattle, BattleTypes.FriendlyBattle::toFriendlyBattle)
                 .setIntegerList("api_touch_plane", bean::setTouchPlane)

--- a/logbook/src/main/java/logbook/bean/BattleTypes.java
+++ b/logbook/src/main/java/logbook/bean/BattleTypes.java
@@ -97,6 +97,15 @@ public class BattleTypes {
         List<List<Integer>> getEParam();
 
         /**
+         * api_e_effect_listを取得します。
+         * 演習相手艦のリボン種別（表示用）。持たない戦闘クラスはnullを返します。
+         * @return api_e_effect_list
+         */
+        default List<List<Integer>> getEEffectList() {
+            return null;
+        }
+
+        /**
          * api_smoke_typeを取得します。
          * 煙幕タイプを持たない戦闘クラスはnullを返します。
          * @return api_smoke_type (0: 無し, 1: 一重煙幕, 2: 二重煙幕, 3: 三重煙幕)

--- a/logbook/src/main/java/logbook/bean/Enemy.java
+++ b/logbook/src/main/java/logbook/bean/Enemy.java
@@ -35,6 +35,12 @@ public class Enemy implements Chara, Serializable {
     /** 演習相手かどうか */
     private boolean practice;
 
+    /**
+     * 特殊効果アイテム種別（演習表示用）
+     * 1: 青リボン, 2: 白タスキ。なしは null
+     */
+    private Integer spEffectKind;
+
     @Override
     public boolean isEnemy() {
         return true;

--- a/logbook/src/main/java/logbook/bean/SortieBattle.java
+++ b/logbook/src/main/java/logbook/bean/SortieBattle.java
@@ -70,6 +70,9 @@ public class SortieBattle
     /** api_eParam */
     private List<List<Integer>> eParam;
 
+    /** api_e_effect_list（演習相手艦のリボン種別・表示用） */
+    private List<List<Integer>> eEffectList;
+
     /** api_search */
     private List<Integer> search;
 
@@ -147,6 +150,7 @@ public class SortieBattle
                 .set("api_eSlot", bean::setESlot, JsonHelper.toList(JsonHelper::toIntegerList))
                 .set("api_fParam", bean::setFParam, JsonHelper.toList(JsonHelper::toIntegerList))
                 .set("api_eParam", bean::setEParam, JsonHelper.toList(JsonHelper::toIntegerList))
+                .set("api_e_effect_list", bean::setEEffectList, JsonHelper.toList(JsonHelper::toIntegerList))
                 .setIntegerList("api_search", bean::setSearch)
                 .setIntegerList("api_formation", bean::setFormation)
                 .setIntegerList("api_stage_flag", bean::setStageFlag)

--- a/logbook/src/main/java/logbook/internal/PhaseState.java
+++ b/logbook/src/main/java/logbook/internal/PhaseState.java
@@ -139,6 +139,7 @@ public class PhaseState {
             }
         }
         // 敵
+        List<List<Integer>> eEffectList = b.getEEffectList();
         for (int i = 0, s = b.getShipKe().size(); i < s; i++) {
             if (b.getShipKe().get(i) != -1) {
                 Enemy e = new Enemy();
@@ -146,6 +147,15 @@ public class PhaseState {
                 e.setLv(b.getShipLv().get(i));
                 e.setSlot(b.getESlot().get(i));
                 e.setOrder(i);
+                if (eEffectList != null && i < eEffectList.size()) {
+                    List<Integer> kinds = eEffectList.get(i);
+                    if (kinds != null && !kinds.isEmpty()) {
+                        Integer kind = kinds.get(0);
+                        if (kind != null && kind != 0) {
+                            e.setSpEffectKind(kind);
+                        }
+                    }
+                }
 
                 this.afterEnemy.add(e);
             }

--- a/logbook/src/main/java/logbook/internal/ShipImage.java
+++ b/logbook/src/main/java/logbook/internal/ShipImage.java
@@ -19,6 +19,7 @@ import javafx.scene.paint.Color;
 import logbook.bean.AppConfig;
 import logbook.bean.Chara;
 import logbook.bean.DeckPortCollection;
+import logbook.bean.Enemy;
 import logbook.bean.NdockCollection;
 import logbook.bean.Ship;
 import logbook.bean.Ship.SpEffectItem;
@@ -251,15 +252,29 @@ class ShipImage {
             boolean isEscape = isShip && Ships.isEscape(chara.asShip(), escape);
 
             // 特殊効果
-            if (isShip && banner && chara.asShip().getSpEffectItems() != null) {
-                for (SpEffectItem spEffectItem : chara.asShip().getSpEffectItems()) {
-                    switch (spEffectItem.getKind()) {
-                        case SpEffectItem.KIND_BLUE_RIBBON:
-                            layers.add(SP_EFFECT_BLUE_RIBBON);
-                            break;
-                        case SpEffectItem.KIND_WHITE_TASUKI:
-                            layers.add(SP_EFFECT_WHITE_TASUKI);
-                            break;
+            if (banner) {
+                if (isShip && chara.asShip().getSpEffectItems() != null) {
+                    for (SpEffectItem spEffectItem : chara.asShip().getSpEffectItems()) {
+                        switch (spEffectItem.getKind()) {
+                            case SpEffectItem.KIND_BLUE_RIBBON:
+                                layers.add(SP_EFFECT_BLUE_RIBBON);
+                                break;
+                            case SpEffectItem.KIND_WHITE_TASUKI:
+                                layers.add(SP_EFFECT_WHITE_TASUKI);
+                                break;
+                        }
+                    }
+                } else if (chara.isEnemy()) {
+                    Enemy enemy = chara.asEnemy();
+                    if (enemy.getSpEffectKind() != null) {
+                        switch (enemy.getSpEffectKind()) {
+                            case SpEffectItem.KIND_BLUE_RIBBON:
+                                layers.add(SP_EFFECT_BLUE_RIBBON);
+                                break;
+                            case SpEffectItem.KIND_WHITE_TASUKI:
+                                layers.add(SP_EFFECT_WHITE_TASUKI);
+                                break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
#### 変更内容
「現在の演習」の相手艦バナーに青リボン／白タスキの描画追加

#### 関連するIssue
Fixes #260