### PR TITLE
クエストAPIのapi_label_type対応とイヤリー判定の修正

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -308,7 +308,7 @@ API レスポンス JSON のうち、bean / ハンドラが把握していない
 3. ハンドラ直下のオブジェクトは `reportUnknownKeys` と `KNOWN`（対応済み ∪ 意図的未対応）を用意する
 4. キャプチャ突合でノイズになった既存キーは `ignore` / `IGNORED_API_DATA_KEYS` に移す（start2 と同じ手順）
 
-`api_max_slotplus` や `api_label_type` など実装が必要な未知キーは別途対応する。
+`api_max_slotplus` など実装が必要な未知キーは別途対応する。
 
 ## API レスポンス記録（開発者向け）
 

--- a/logbook/src/main/java/logbook/bean/AppQuest.java
+++ b/logbook/src/main/java/logbook/bean/AppQuest.java
@@ -58,37 +58,9 @@ public class AppQuest implements Serializable {
                 .truncatedTo(ChronoUnit.DAYS);
         ZonedDateTime expire = null;
 
-        int type = quest.getType();
-        int yearlyResetMonth = 0;
-        
-        AppQuestCondition condition = AppQuestCondition.loadFromResource(quest.getNo());
-        if (condition != null) {
-            String resetType = condition.getResetType();
-            if (resetType != null) {
-                switch (resetType) {
-                case "デイリー":
-                    type = DAILY;
-                    break;
-                case "ウィークリー":
-                    type = WEEKLY;
-                    break;
-                case "マンスリー":
-                    type = MONTHLY;
-                    break;
-                case "単発":
-                    type = ONECE;
-                    break;
-                case "クオータリー":
-                case "クォータリー":
-                    type = QUARTRELY;
-                    break;
-                case "イヤリー":
-                    type = YEARLY;
-                    yearlyResetMonth = condition.getYearlyResetMonth();
-                    break;
-                }
-            }
-        }
+        Cycle cycle = resolveCycle(quest);
+        int type = cycle.type();
+        int yearlyResetMonth = cycle.yearlyResetMonth();
 
         if (type == DAILY) {
             // 1=デイリー
@@ -139,5 +111,76 @@ public class AppQuest implements Serializable {
         }
 
         return bean;
+    }
+
+    /**
+     * 周期を決める。{@code labelType}（既知）を正とし、無ければ条件 JSON、それも無ければ {@code api_type}。
+     */
+    private static Cycle resolveCycle(Quest quest) {
+        Cycle fromLabel = cycleFromLabelType(quest.getLabelType());
+        if (fromLabel != null) {
+            return fromLabel;
+        }
+        Cycle fromCondition = cycleFromCondition(quest.getNo());
+        if (fromCondition != null) {
+            return fromCondition;
+        }
+        Integer apiType = quest.getType();
+        return new Cycle(apiType != null ? apiType : 0, 0);
+    }
+
+    /**
+     * {@code api_label_type} から周期を決める。未知・未設定は null。
+     */
+    private static Cycle cycleFromLabelType(Integer labelType) {
+        if (labelType == null) {
+            return null;
+        }
+        return switch (labelType) {
+        case 1 -> new Cycle(ONECE, 0);
+        case 2 -> new Cycle(DAILY, 0);
+        case 3 -> new Cycle(WEEKLY, 0);
+        case 6 -> new Cycle(MONTHLY, 0);
+        case 7 -> new Cycle(QUARTRELY, 0);
+        default -> {
+            if (labelType >= 101 && labelType <= 112) {
+                yield new Cycle(YEARLY, labelType - 100);
+            }
+            yield null;
+        }
+        };
+    }
+
+    /**
+     * 条件 JSON の {@code resetType} / {@code yearlyResetMonth} から周期を決める。無ければ null。
+     */
+    private static Cycle cycleFromCondition(Integer questNo) {
+        if (questNo == null) {
+            return null;
+        }
+        AppQuestCondition condition = AppQuestCondition.loadFromResource(questNo);
+        if (condition == null) {
+            return null;
+        }
+        String resetType = condition.getResetType();
+        if (resetType == null) {
+            return null;
+        }
+        return switch (resetType) {
+        case "デイリー" -> new Cycle(DAILY, 0);
+        case "ウィークリー" -> new Cycle(WEEKLY, 0);
+        case "マンスリー" -> new Cycle(MONTHLY, 0);
+        case "単発" -> new Cycle(ONECE, 0);
+        case "クオータリー", "クォータリー" -> new Cycle(QUARTRELY, 0);
+        case "イヤリー" -> new Cycle(YEARLY,
+                condition.getYearlyResetMonth() != null ? condition.getYearlyResetMonth() : 0);
+        default -> null;
+        };
+    }
+
+    /**
+     * expire 計算用の内部周期。{@code api_type} の番号とは一致しない場合がある。
+     */
+    private record Cycle(int type, int yearlyResetMonth) {
     }
 }

--- a/logbook/src/main/java/logbook/bean/AppQuestCondition.java
+++ b/logbook/src/main/java/logbook/bean/AppQuestCondition.java
@@ -27,10 +27,10 @@ public class AppQuestCondition implements Predicate<QuestCollect> {
     /** 任務のタイプ(enum: 出撃, 遠征) */
     private Type type;
 
-    /** 任務期間(文字列:単発,デイリー,ウィークリー,マンスリー,クオータリー) */
+    /** 任務期間(文字列:単発,デイリー,ウィークリー,マンスリー,クオータリー)。周期・期限は {@code api_label_type} 優先。labelType が無い・未知のときのみ使用 */
     private String resetType;
 
-    /** イヤリーのリセット月（イヤリー8月なら8） */
+    /** イヤリーのリセット月（イヤリー8月なら8）。周期・期限は {@code api_label_type} 優先。labelType が無い・未知のときのみ使用 */
     private Integer yearlyResetMonth;
 
     /** フィルター条件 */

--- a/logbook/src/main/java/logbook/bean/QuestList.java
+++ b/logbook/src/main/java/logbook/bean/QuestList.java
@@ -52,6 +52,9 @@ public class QuestList implements Serializable {
         /** api_type */
         private Integer type;
 
+        /** api_label_type */
+        private Integer labelType;
+
         /** api_state */
         private Integer state;
 
@@ -87,6 +90,7 @@ public class QuestList implements Serializable {
                         .setInteger("api_no", bean::setNo)
                         .setInteger("api_category", bean::setCategory)
                         .setInteger("api_type", bean::setType)
+                        .setInteger("api_label_type", bean::setLabelType)
                         .setInteger("api_state", bean::setState)
                         .setString("api_title", bean::setTitle)
                         .setString("api_detail", bean::setDetail)

--- a/logbook/src/test/java/logbook/bean/AppQuestDurationTest.java
+++ b/logbook/src/test/java/logbook/bean/AppQuestDurationTest.java
@@ -22,6 +22,8 @@ import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
 import logbook.bean.AppQuestDuration.Duration;
+import logbook.bean.QuestList.Quest;
+import logbook.internal.Logs;
 import logbook.plugin.PluginContainer;
 
 public class AppQuestDurationTest {
@@ -36,6 +38,16 @@ public class AppQuestDurationTest {
                         .getJsonObject("api_data");
                 QuestList list = QuestList.toQuestList(json);
                 assertNotNull(list);
+                assertEquals(3, list.getList().stream()
+                        .filter(q -> q.getNo() == 213)
+                        .findFirst()
+                        .orElseThrow()
+                        .getLabelType());
+                assertEquals(108, list.getList().stream()
+                        .filter(q -> q.getNo() == 438)
+                        .findFirst()
+                        .orElseThrow()
+                        .getLabelType());
                 list.getList().stream()
                     .map(AppQuest::toAppQuest)
                     .filter(Objects::nonNull)
@@ -94,5 +106,59 @@ public class AppQuestDurationTest {
                 assertNull(value.get(924).get(0).getTo());
             }
         }
+    }
+
+    @Test
+    public void toAppQuest_prefersLabelTypeOverConditionJson() {
+        PluginContainer.getInstance().init(Collections.emptyList());
+        // 861 の条件 JSON はクォータリー。labelType=108 ならイヤーリー8月
+        Quest quest = new Quest();
+        quest.setNo(861);
+        quest.setType(5);
+        quest.setLabelType(108);
+        quest.setState(1);
+
+        AppQuest appQuest = AppQuest.toAppQuest(quest);
+        assertEquals(yearlyExpire(8), appQuest.getExpire());
+    }
+
+    @Test
+    public void toAppQuest_fallsBackToConditionJsonWhenLabelTypeAbsent() {
+        PluginContainer.getInstance().init(Collections.emptyList());
+        // 438 の条件 JSON はイヤーリー8月
+        Quest quest = new Quest();
+        quest.setNo(438);
+        quest.setType(5);
+        quest.setLabelType(null);
+        quest.setState(1);
+
+        AppQuest appQuest = AppQuest.toAppQuest(quest);
+        assertEquals(yearlyExpire(8), appQuest.getExpire());
+    }
+
+    @Test
+    public void toAppQuest_fallsBackToApiTypeWhenLabelTypeAndJsonAbsent() {
+        PluginContainer.getInstance().init(Collections.emptyList());
+        Quest quest = new Quest();
+        quest.setNo(9_999_999);
+        quest.setType(1);
+        quest.setLabelType(null);
+        quest.setState(1);
+
+        AppQuest appQuest = AppQuest.toAppQuest(quest);
+        ZonedDateTime today = ZonedDateTime.now(ZoneId.of("GMT+04:00")).truncatedTo(ChronoUnit.DAYS);
+        String daily = today.plusDays(1)
+                .withZoneSameInstant(ZoneId.of("Asia/Tokyo"))
+                .format(Logs.DATE_FORMAT);
+        assertEquals(daily, appQuest.getExpire());
+    }
+
+    private static String yearlyExpire(int month) {
+        ZonedDateTime today = ZonedDateTime.now(ZoneId.of("GMT+04:00")).truncatedTo(ChronoUnit.DAYS);
+        ZonedDateTime tmp = today.plusMonths(1).withDayOfMonth(1);
+        while (tmp.getMonthValue() != month) {
+            tmp = tmp.plusMonths(1);
+        }
+        return tmp.withZoneSameInstant(ZoneId.of("Asia/Tokyo")).format(Logs.DATE_FORMAT);
     }
 }


### PR DESCRIPTION
#### 変更内容
クエストAPIの`api_label_type`に対応
`api_label_type`をイヤリーの判定に使用するように修正
これにより、クエスト設定JSONに`yearlyResetMonth`の記載は不要となる

#### 関連するIssue
Fixes #263
