### PR TITLE
api_c_listを読み込み対象外とする

### DIFF
--- a/logbook/src/main/java/logbook/bean/QuestList.java
+++ b/logbook/src/main/java/logbook/bean/QuestList.java
@@ -126,7 +126,9 @@ public class QuestList implements Serializable {
                 .setInteger("api_disp_page", bean::setDispPage)
                 .set("api_list", bean::setList, JsonHelper.toList(Quest::toQuest))
                 .setInteger("api_exec_count", bean::setExecCount)
-                .ignore("api_exec_type") // 実行タイプ
+                .ignore(
+                        "api_exec_type", // 実行タイプ
+                        "api_c_list") // 特殊条件判定
                 .reportUnknown();
         return bean;
     }


### PR DESCRIPTION
#### 変更内容
`QuestList` の `api_c_list` は対象外とする。

#### 関連するIssue
Fixes #268